### PR TITLE
Feat: ANT-3383 - AREA Trajectory deletion control

### DIFF
--- a/src/main/java/com/rte_france/antares/datamanager_back/controller/TrajectoryController.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/controller/TrajectoryController.java
@@ -103,6 +103,12 @@ public class TrajectoryController {
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
+    @DeleteMapping("/detach/all")
+    public ResponseEntity<Void> unlinkAllTrajectoriesFromStudy(@RequestParam Integer studyId) {
+        trajectoryService.unlinkAllTrajectoriesFromStudy(studyId);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
     @Operation(summary = "Get trajectory data")
     @GetMapping(value = "/trajectoryData")
     public ResponseEntity<List<TrajectoryDataDTO>> findTrajectoriesByTypeFromFileSystem(

--- a/src/main/java/com/rte_france/antares/datamanager_back/repository/StudyTrajectoryRepository.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/repository/StudyTrajectoryRepository.java
@@ -4,5 +4,8 @@ import com.rte_france.antares.datamanager_back.repository.model.StudyTrajectoryE
 import com.rte_france.antares.datamanager_back.repository.model.StudyTrajectoryKey;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface StudyTrajectoryRepository extends JpaRepository<StudyTrajectoryEntity, StudyTrajectoryKey> {
+  List<StudyTrajectoryEntity> findById_ScenarioId(Integer scenarioId);
 }

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/TrajectoryService.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/TrajectoryService.java
@@ -27,6 +27,8 @@ public interface TrajectoryService {
 
     void unlinkTrajectoryFromStudy(Integer trajectoryId, Integer studyId);
 
+    void unlinkAllTrajectoriesFromStudy(Integer studyId);
+
     List<TrajectoryDataDTO> getTrajectoryDataByTypeAndId(TrajectoryType trajectoryType, Integer trajectoryId);
 
     Map<String, Integer> countWarningMessage(Integer studyId);

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/impl/TrajectoryServiceImpl.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/impl/TrajectoryServiceImpl.java
@@ -615,7 +615,7 @@ public class TrajectoryServiceImpl implements TrajectoryService {
         var links = studyTrajectoryRepository.findAll()
                 .stream()
                 .filter(link -> link.getId().getScenarioId().equals(studyId))
-                .collect(Collectors.toList());
+                .toList();
         studyTrajectoryRepository.deleteAll(links);
     }
 

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/impl/TrajectoryServiceImpl.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/impl/TrajectoryServiceImpl.java
@@ -598,7 +598,7 @@ public class TrajectoryServiceImpl implements TrajectoryService {
                         .httpStatus(HttpStatus.BAD_REQUEST)
                         .build());
 
-        if (trajectory.getType().equals("AREA")) {
+        if (trajectory.getType().equals(TrajectoryType.AREA.name())) {
             var others = getOtherTrajectoriesLinkedToStudy(studyId, trajectoryId);
             if (!others.isEmpty()) {
                 throw BusinessException.builder()
@@ -612,10 +612,7 @@ public class TrajectoryServiceImpl implements TrajectoryService {
     @Override
     @Transactional
     public void unlinkAllTrajectoriesFromStudy(Integer studyId) {
-        var links = studyTrajectoryRepository.findAll()
-                .stream()
-                .filter(link -> link.getId().getScenarioId().equals(studyId))
-                .toList();
+        var links = studyTrajectoryRepository.findById_ScenarioId(studyId);
         studyTrajectoryRepository.deleteAll(links);
     }
 

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/impl/TrajectoryServiceImpl.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/impl/TrajectoryServiceImpl.java
@@ -568,6 +568,8 @@ public class TrajectoryServiceImpl implements TrajectoryService {
 
     @Override
     public void unlinkTrajectoryFromStudy(Integer trajectoryId, Integer studyId) {
+        validateAreaTrajectoryDeletion(trajectoryId, studyId);
+
         studyTrajectoryRepository.findById(StudyTrajectoryKey.builder()
                         .trajectoryId(trajectoryId)
                         .scenarioId(studyId)
@@ -581,6 +583,41 @@ public class TrajectoryServiceImpl implements TrajectoryService {
                         });
     }
 
+    private List<TrajectoryEntity> getOtherTrajectoriesLinkedToStudy(Integer studyId, Integer excludedTrajectoryId) {
+        return trajectoryRepository.findByTypeAndStudyId(null, studyId)
+                .stream()
+                .filter(t -> !t.getId().equals(excludedTrajectoryId))
+                .toList();
+    }
+
+
+    private void validateAreaTrajectoryDeletion(Integer trajectoryId, Integer studyId) {
+        var trajectory = trajectoryRepository.findById(trajectoryId)
+                .orElseThrow(() -> BusinessException.builder()
+                        .message("Trajectory not found")
+                        .httpStatus(HttpStatus.BAD_REQUEST)
+                        .build());
+
+        if (trajectory.getType().equals("AREA")) {
+            var others = getOtherTrajectoriesLinkedToStudy(studyId, trajectoryId);
+            if (!others.isEmpty()) {
+                throw BusinessException.builder()
+                        .message("Other trajectories are linked. Confirmation required")
+                        .httpStatus(HttpStatus.CONFLICT)
+                        .build();
+            }
+        }
+    }
+
+    @Override
+    @Transactional
+    public void unlinkAllTrajectoriesFromStudy(Integer studyId) {
+        var links = studyTrajectoryRepository.findAll()
+                .stream()
+                .filter(link -> link.getId().getScenarioId().equals(studyId))
+                .collect(Collectors.toList());
+        studyTrajectoryRepository.deleteAll(links);
+    }
 
     @Override
     public List<TrajectoryDataDTO> getTrajectoryDataByTypeAndId(TrajectoryType trajectoryType, Integer trajectoryId) {

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/impl/TrajectoryServiceImpl.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/impl/TrajectoryServiceImpl.java
@@ -12,7 +12,6 @@ import com.rte_france.antares.datamanager_back.repository.model.*;
 import com.rte_france.antares.datamanager_back.service.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,8 +25,6 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.*;
 import java.util.stream.Collectors;
-
-import static com.rte_france.antares.datamanager_back.util.Utils.OTHERS_AREA;
 
 import static com.rte_france.antares.datamanager_back.util.Utils.*;
 
@@ -613,7 +610,14 @@ public class TrajectoryServiceImpl implements TrajectoryService {
     @Transactional
     public void unlinkAllTrajectoriesFromStudy(Integer studyId) {
         var links = studyTrajectoryRepository.findById_ScenarioId(studyId);
-        studyTrajectoryRepository.deleteAll(links);
+        if (!links.isEmpty()) {
+            studyTrajectoryRepository.deleteAll(links);
+        } else {
+            throw BusinessException.builder()
+                    .message("No links found")
+                    .httpStatus(HttpStatus.BAD_REQUEST)
+                    .build();
+        }
     }
 
     @Override

--- a/src/test/java/com/rte_france/antares/datamanager_back/controller/TrajectoryControllerTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/controller/TrajectoryControllerTest.java
@@ -23,7 +23,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import java.util.List;
-import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -207,6 +206,20 @@ class TrajectoryControllerTest {
                 .andExpect(status().isNotFound());
     }
 
+    @Test
+    void unlinkTrajectoryFromStudy_returnsConflictWhenAreaHasOtherLinks() throws Exception {
+        doThrow(BusinessException.builder()
+                .message("Other trajectories are linked. Confirmation required")
+                .httpStatus(HttpStatus.CONFLICT)
+                .build())
+                .when(trajectoryServiceImpl).unlinkTrajectoryFromStudy(1, 1);
+
+        this.mockMvc.perform(delete("/v1/trajectory/detach")
+                        .param("trajectoryId", "1")
+                        .param("studyId", "1")
+                        .accept(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().isConflict());
+    }
 
     @Test
     void getTrajectoryDataByTypeAndId() throws Exception {

--- a/src/test/java/com/rte_france/antares/datamanager_back/controller/TrajectoryControllerTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/controller/TrajectoryControllerTest.java
@@ -222,6 +222,18 @@ class TrajectoryControllerTest {
     }
 
     @Test
+    void unlinkAllTrajectoriesFromStudy_returnsNoContent() throws Exception {
+        doNothing().when(trajectoryServiceImpl).unlinkAllTrajectoriesFromStudy(1);
+
+        this.mockMvc.perform(delete("/v1/trajectory/detach/all")
+                        .param("studyId", "1")
+                        .accept(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().isNoContent());
+
+        verify(trajectoryServiceImpl, times(1)).unlinkAllTrajectoriesFromStudy(1);
+    }
+
+    @Test
     void getTrajectoryDataByTypeAndId() throws Exception {
         AreaTrajectoryDataDTO trajectoryDataDTO = AreaTrajectoryDataDTO.builder()
                 .areaName("AT")

--- a/src/test/java/com/rte_france/antares/datamanager_back/repository/StudyTrajectoryRepositoryTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/repository/StudyTrajectoryRepositoryTest.java
@@ -1,0 +1,43 @@
+package com.rte_france.antares.datamanager_back.repository;
+
+import com.rte_france.antares.datamanager_back.repository.model.StudyTrajectoryEntity;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Sql(executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD, scripts = "classpath:db/init_db.sql")
+@Sql(executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD, scripts = "classpath:db/init_test_trajectories.sql")
+@Sql(executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, scripts = "classpath:db/clean_db.sql")
+class StudyTrajectoryRepositoryTest {
+
+    @Autowired
+    private StudyTrajectoryRepository studyTrajectoryRepository;
+
+    @Test
+    void findById_ScenarioId_returnsEntitiesForExistingScenarioId() {
+        var scenarioId = 1;
+        var result = studyTrajectoryRepository.findById_ScenarioId(scenarioId);
+
+        assertThat(result).isNotNull();
+        assertThat(result).isNotEmpty();
+        assertThat(result).allMatch(e -> e.getId().getScenarioId().equals(scenarioId));
+    }
+
+    @Test
+    void findById_ScenarioId_returnsEmptyListForNonExistentScenarioId() {
+        var scenarioId = 9999;
+        var result = studyTrajectoryRepository.findById_ScenarioId(scenarioId);
+
+        assertThat(result).isNotNull();
+        assertThat(result).isEmpty();
+    }
+}

--- a/src/test/java/com/rte_france/antares/datamanager_back/repository/StudyTrajectoryRepositoryTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/repository/StudyTrajectoryRepositoryTest.java
@@ -1,14 +1,11 @@
 package com.rte_france.antares.datamanager_back.repository;
 
-import com.rte_france.antares.datamanager_back.repository.model.StudyTrajectoryEntity;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -27,9 +24,11 @@ class StudyTrajectoryRepositoryTest {
         var scenarioId = 1;
         var result = studyTrajectoryRepository.findById_ScenarioId(scenarioId);
 
-        assertThat(result).isNotNull();
-        assertThat(result).isNotEmpty();
-        assertThat(result).allMatch(e -> e.getId().getScenarioId().equals(scenarioId));
+        assertThat(result)
+                .isNotNull()
+                .isNotEmpty()
+                .extracting(e -> e.getId().getScenarioId())
+                .allMatch(id -> id.equals(scenarioId));
     }
 
     @Test
@@ -37,7 +36,8 @@ class StudyTrajectoryRepositoryTest {
         var scenarioId = 9999;
         var result = studyTrajectoryRepository.findById_ScenarioId(scenarioId);
 
-        assertThat(result).isNotNull();
-        assertThat(result).isEmpty();
+        assertThat(result)
+                .isNotNull()
+                .isEmpty();
     }
 }

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/TrajectoryServiceImplAdditionalTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/TrajectoryServiceImplAdditionalTest.java
@@ -4,7 +4,6 @@ import com.rte_france.antares.datamanager_back.configuration.AntaressDataManager
 import com.rte_france.antares.datamanager_back.dto.TrajectoryType;
 import com.rte_france.antares.datamanager_back.dto.UserInfoDto;
 import com.rte_france.antares.datamanager_back.exception.BusinessException;
-import com.rte_france.antares.datamanager_back.exception.TechnicalException;
 import com.rte_france.antares.datamanager_back.repository.*;
 import com.rte_france.antares.datamanager_back.repository.model.*;
 import com.rte_france.antares.datamanager_back.service.impl.LoadFileProcessorServiceImpl;
@@ -269,5 +268,28 @@ class TrajectoryServiceImplAdditionalTest {
             assertEquals(HttpStatus.BAD_REQUEST, ex.getHttpStatus());
             assertTrue(ex.getMessage().contains("already uploaded"));
         }
+    }
+
+    @Test
+    void unlinkAllTrajectoriesFromStudy_deletesLinksWhenFound() {
+        var studyId = 1;
+        var links = List.of(
+                StudyTrajectoryEntity.builder().build()
+        );
+        when(studyTrajectoryRepository.findById_ScenarioId(studyId)).thenReturn(links);
+
+        assertDoesNotThrow(() -> trajectoryService.unlinkAllTrajectoriesFromStudy(studyId));
+        verify(studyTrajectoryRepository).deleteAll(links);
+    }
+
+    @Test
+    void unlinkAllTrajectoriesFromStudy_throwsExceptionWhenNoLinksFound() {
+        var studyId = 999;
+        when(studyTrajectoryRepository.findById_ScenarioId(studyId)).thenReturn(Collections.emptyList());
+
+        var ex = assertThrows(BusinessException.class, () ->
+                trajectoryService.unlinkAllTrajectoriesFromStudy(studyId));
+        assertEquals("No links found", ex.getMessage());
+        assertEquals(HttpStatus.BAD_REQUEST, ex.getHttpStatus());
     }
 }

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/TrajectoryServiceImplAdditionalTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/TrajectoryServiceImplAdditionalTest.java
@@ -3,11 +3,9 @@ package com.rte_france.antares.datamanager_back.service;
 import com.rte_france.antares.datamanager_back.configuration.AntaressDataManagerProperties;
 import com.rte_france.antares.datamanager_back.dto.TrajectoryType;
 import com.rte_france.antares.datamanager_back.dto.UserInfoDto;
+import com.rte_france.antares.datamanager_back.exception.BusinessException;
 import com.rte_france.antares.datamanager_back.exception.TechnicalException;
-import com.rte_france.antares.datamanager_back.repository.AreaRepository;
-import com.rte_france.antares.datamanager_back.repository.LoadRepository;
-import com.rte_france.antares.datamanager_back.repository.StudyTrajectoryRepository;
-import com.rte_france.antares.datamanager_back.repository.TrajectoryRepository;
+import com.rte_france.antares.datamanager_back.repository.*;
 import com.rte_france.antares.datamanager_back.repository.model.*;
 import com.rte_france.antares.datamanager_back.service.impl.LoadFileProcessorServiceImpl;
 import com.rte_france.antares.datamanager_back.service.impl.TrajectoryServiceImpl;
@@ -26,10 +24,7 @@ import org.springframework.http.HttpStatus;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -218,6 +213,61 @@ class TrajectoryServiceImplAdditionalTest {
 
             // Verify that trajectoryRepository.findByTypeAndStudyId was called with the correct parameters
             verify(trajectoryRepository).findByTypeAndStudyId(TrajectoryType.LOAD.name(), studyId);
+        }
+    }
+
+    @Test
+    void saveLoadTrajectoriesInDb_throwsBadRequestWhenParamsAreNull() {
+        var ex = assertThrows(BusinessException.class, () ->
+                trajectoryService.saveLoadTrajectoriesInDb(null, "trajectory", "2023-2024", 1)
+        );
+        assertEquals(HttpStatus.BAD_REQUEST, ex.getHttpStatus());
+        assertTrue(ex.getMessage().contains("must not be null"));
+
+        ex = assertThrows(BusinessException.class, () ->
+                trajectoryService.saveLoadTrajectoriesInDb("area", null, "2023-2024", 1)
+        );
+        assertEquals(HttpStatus.BAD_REQUEST, ex.getHttpStatus());
+
+        ex = assertThrows(BusinessException.class, () ->
+                trajectoryService.saveLoadTrajectoriesInDb("area", "trajectory", null, 1)
+        );
+        assertEquals(HttpStatus.BAD_REQUEST, ex.getHttpStatus());
+    }
+
+    @Test
+    void saveLoadTrajectoriesInDb_throwsBadRequestWhenTrajectoryAlreadyUploaded() {
+        var area = "FR";
+        var trajectoryToUse = "testTrajectory";
+        var horizon = "2023-2024";
+        var studyId = 1;
+
+        when(userService.getCurrentUserDetails())
+                .thenReturn(UserInfoDto.builder().nni("user").build());
+
+        when(areaRepository.findAreaByNameAndStudyId(area, studyId))
+                .thenReturn(Optional.of(AreaEntity.builder().name(area).build()));
+
+        when(antaressDataManagerProperties.getNasDirectory()).thenReturn("/tmp");
+        when(antaressDataManagerProperties.getTrajectoryFilePath()).thenReturn("");
+        when(antaressDataManagerProperties.getLoadDirectory()).thenReturn("");
+
+        var existingTrajectory = TrajectoryEntity.builder()
+                .fileName(trajectoryToUse)
+                .horizon(horizon)
+                .loadArea(area)
+                .build();
+        when(trajectoryRepository.findFirstByFileNameAndHorizonAndLoadAreaOrderByVersionDesc(trajectoryToUse, horizon, area))
+                .thenReturn(Optional.of(existingTrajectory));
+
+        try (var utilsMock = mockStatic(Utils.class)) {
+            utilsMock.when(() -> Utils.isSameLoadTrajectory(any(), eq(existingTrajectory))).thenReturn(true);
+
+            var ex = assertThrows(BusinessException.class, () ->
+                    trajectoryService.saveLoadTrajectoriesInDb(area, trajectoryToUse, horizon, studyId)
+            );
+            assertEquals(HttpStatus.BAD_REQUEST, ex.getHttpStatus());
+            assertTrue(ex.getMessage().contains("already uploaded"));
         }
     }
 }

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/TrajectoryServiceImplTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/TrajectoryServiceImplTest.java
@@ -861,4 +861,43 @@ class TrajectoryServiceImplTest {
             assertTrue(fileNames.contains("load_de_2030-2031.txt"));
         }
     }
+
+    @Test
+    void linkTrajectoryToStudy_shouldCheckForMissingLoadFilesAndSaveWarnings_whenLoadTypeAndOtherArea() throws IOException {
+        var trajectoryId = 1;
+        var studyId = 2;
+        var userNni = "user";
+        var fileName = "traj";
+        var horizon = "2023-2024";
+
+        var study = StudyEntity.builder().id(studyId).build();
+        var trajectory = TrajectoryEntity.builder()
+                .id(trajectoryId)
+                .type(TrajectoryType.LOAD.name())
+                .loadArea(TrajectoryServiceImpl.OTHER_AREA)
+                .fileName(fileName)
+                .horizon(horizon)
+                .build();
+
+        var warning1 = new WarningMessageEntity();
+        var warning2 = new WarningMessageEntity();
+        var warnings = new HashSet<>(List.of(warning1, warning2));
+
+        when(studyRepository.findById(studyId)).thenReturn(Optional.of(study));
+        when(trajectoryRepository.findById(trajectoryId)).thenReturn(Optional.of(trajectory));
+        when(userService.getCurrentUserDetails()).thenReturn(UserInfoDto.builder().nni(userNni).build());
+        when(antaressDataManagerProperties.getNasDirectory()).thenReturn("/tmp");
+        when(antaressDataManagerProperties.getTrajectoryFilePath()).thenReturn("");
+        when(antaressDataManagerProperties.getLoadDirectory()).thenReturn("");
+        when(loadFileProcessorService.checkForMissingLoadFiles(any(), eq(horizon), eq(studyId), eq(userNni), eq(trajectory)))
+                .thenReturn(warnings);
+        when(studyTrajectoryRepository.save(any())).thenReturn(StudyTrajectoryEntity.builder().trajectory(trajectory).build());
+
+        trajectoryService.linkTrajectoryToStudy(trajectoryId, studyId, TrajectoryType.LOAD);
+
+        assertTrue(warnings.stream().allMatch(w -> w.getTrajectory() == trajectory));
+        assertTrue(warnings.stream().allMatch(w -> w.getStudy() == study));
+        verify(warningRepository).saveAll(warnings);
+        verify(loadFileProcessorService).checkForMissingLoadFiles(any(), eq(horizon), eq(studyId), eq(userNni), eq(trajectory));
+    }
 }

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/TrajectoryServiceImplTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/TrajectoryServiceImplTest.java
@@ -11,7 +11,6 @@ import com.rte_france.antares.datamanager_back.service.impl.TrajectoryServiceImp
 import com.rte_france.antares.datamanager_back.service.impl.UserService;
 import com.rte_france.antares.datamanager_back.util.Utils;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.InjectMocks;
@@ -22,7 +21,6 @@ import org.springframework.http.HttpStatus;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -285,15 +283,61 @@ class TrajectoryServiceImplTest {
 
     @Test
     void unlinkTrajectoryFromStudy_unlinksWhenLinkExists() {
+        // Given
         Integer trajectoryId = 1;
         Integer studyId = 1;
         StudyTrajectoryKey key = StudyTrajectoryKey.builder().trajectoryId(trajectoryId).scenarioId(studyId).build();
         StudyTrajectoryEntity entity = StudyTrajectoryEntity.builder().id(key).build();
 
+        // When
+        TrajectoryEntity trajectory = TrajectoryEntity.builder().id(trajectoryId).type("LINK").build();
+        when(trajectoryRepository.findById(trajectoryId)).thenReturn(Optional.of(trajectory));
         when(studyTrajectoryRepository.findById(key)).thenReturn(Optional.of(entity));
 
         trajectoryService.unlinkTrajectoryFromStudy(trajectoryId, studyId);
 
+        // Then
+        verify(studyTrajectoryRepository, times(1)).delete(entity);
+    }
+
+
+    @Test
+    void unlinkTrajectoryFromStudy_throwsConflictWhenAreaAndOtherTrajectoriesLinked() {
+        // Given
+        var trajectoryId = 1;
+        var studyId = 1;
+
+        // When
+        var areaTrajectory = TrajectoryEntity.builder().id(trajectoryId).type("AREA").build();
+        when(trajectoryRepository.findById(trajectoryId)).thenReturn(Optional.of(areaTrajectory));
+
+        var otherTrajectory = TrajectoryEntity.builder().id(2).type("LINK").build();
+        when(trajectoryRepository.findByTypeAndStudyId(null, studyId)).thenReturn(List.of(areaTrajectory, otherTrajectory));
+
+        // Then
+        BusinessException ex = assertThrows(BusinessException.class, () ->
+                trajectoryService.unlinkTrajectoryFromStudy(trajectoryId, studyId));
+        assertEquals(HttpStatus.CONFLICT, ex.getHttpStatus());
+        assertTrue(ex.getMessage().contains("Other trajectories are linked"));
+    }
+
+    @Test
+    void unlinkTrajectoryFromStudy_unlinksWhenAreaAndNoOtherTrajectoriesLinked() {
+        // Given
+        var trajectoryId = 1;
+        var studyId = 1;
+        var key = StudyTrajectoryKey.builder().trajectoryId(trajectoryId).scenarioId(studyId).build();
+        var entity = StudyTrajectoryEntity.builder().id(key).build();
+
+        // When
+        var areaTrajectory = TrajectoryEntity.builder().id(trajectoryId).type("AREA").build();
+        when(trajectoryRepository.findById(trajectoryId)).thenReturn(Optional.of(areaTrajectory));
+        when(trajectoryRepository.findByTypeAndStudyId(null, studyId)).thenReturn(List.of(areaTrajectory));
+        when(studyTrajectoryRepository.findById(key)).thenReturn(Optional.of(entity));
+
+        trajectoryService.unlinkTrajectoryFromStudy(trajectoryId, studyId);
+
+        // Then
         verify(studyTrajectoryRepository, times(1)).delete(entity);
     }
 
@@ -560,7 +604,7 @@ class TrajectoryServiceImplTest {
     }
 
     @Test
-    void shouldCallCheckForMissingLoadFilesWhenOtherArea() throws IOException {
+    void shouldCallCheckForMissingLoadFilesWhenOtherArea() {
         String area = "OTHERS";
         String horizon = "2023-2024";
         String trajectoryToUse = "testTrajectory";


### PR DESCRIPTION
- `unlinkTrajectoryFromStudy` now checks if the trajectory is of AREA type
- It throws a `BusinessException` with `Conflict` HTTP status, to be handled in the front (show confirmation dialog)
- Added a `/detach/all` for calling from the front after user confirms deletion of AREA trajectory