### PR TITLE
Feature/ANT-3698 Unlink multiple trajectories simultaneously 

### DIFF
--- a/src/main/java/com/rte_france/antares/datamanager_back/controller/TrajectoryController.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/controller/TrajectoryController.java
@@ -103,6 +103,14 @@ public class TrajectoryController {
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
+    @Operation(summary = "Detach multiple trajectories from a study")
+    @PostMapping("/detach/batch")
+    public ResponseEntity<Map<String, List<Integer>>> unlinkBatch(@RequestParam Integer studyId,
+                                            @RequestBody List<Integer> trajectoryIds) {
+        var result = trajectoryService.unlinkBatchTrajectoriesFromStudy(studyId, trajectoryIds);
+        return new ResponseEntity<>(result, HttpStatus.OK);
+    }
+
     @DeleteMapping("/detach/all")
     public ResponseEntity<Void> unlinkAllTrajectoriesFromStudy(@RequestParam Integer studyId) {
         trajectoryService.unlinkAllTrajectoriesFromStudy(studyId);

--- a/src/main/java/com/rte_france/antares/datamanager_back/controller/TrajectoryController.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/controller/TrajectoryController.java
@@ -105,10 +105,10 @@ public class TrajectoryController {
 
     @Operation(summary = "Detach multiple trajectories from a study")
     @PostMapping("/detach/batch")
-    public ResponseEntity<Map<String, List<Integer>>> unlinkBatch(@RequestParam Integer studyId,
+    public ResponseEntity<Void> unlinkBatch(@RequestParam Integer studyId,
                                             @RequestBody List<Integer> trajectoryIds) {
-        var result = trajectoryService.unlinkBatchTrajectoriesFromStudy(studyId, trajectoryIds);
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        trajectoryService.unlinkBatchTrajectoriesFromStudy(studyId, trajectoryIds);
+        return ResponseEntity.noContent().build();
     }
 
     @DeleteMapping("/detach/all")

--- a/src/main/java/com/rte_france/antares/datamanager_back/repository/StudyTrajectoryRepository.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/repository/StudyTrajectoryRepository.java
@@ -3,9 +3,17 @@ package com.rte_france.antares.datamanager_back.repository;
 import com.rte_france.antares.datamanager_back.repository.model.StudyTrajectoryEntity;
 import com.rte_france.antares.datamanager_back.repository.model.StudyTrajectoryKey;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface StudyTrajectoryRepository extends JpaRepository<StudyTrajectoryEntity, StudyTrajectoryKey> {
   List<StudyTrajectoryEntity> findById_ScenarioId(Integer scenarioId);
+
+  @Modifying
+  @Query("DELETE FROM studyTrajectory e " +
+          "WHERE e.id.scenarioId = :studyId AND e.id.trajectoryId IN :trajectoryIds")
+  int deleteByStudyIdAndTrajectoryIds(@Param("studyId") Integer studyId, @Param("trajectoryIds") List<Integer> trajectoryIds);
 }

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/TrajectoryService.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/TrajectoryService.java
@@ -29,6 +29,8 @@ public interface TrajectoryService {
 
     void unlinkTrajectoryFromStudy(Integer trajectoryId, Integer studyId);
 
+    Map<String, List<Integer>> unlinkBatchTrajectoriesFromStudy(Integer studyId, List<Integer> trajectoryIds);
+
     void unlinkAllTrajectoriesFromStudy(Integer studyId);
 
     List<TrajectoryDataDTO> getTrajectoryDataByTypeAndId(TrajectoryType trajectoryType, Integer trajectoryId);

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/TrajectoryService.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/TrajectoryService.java
@@ -29,7 +29,7 @@ public interface TrajectoryService {
 
     void unlinkTrajectoryFromStudy(Integer trajectoryId, Integer studyId);
 
-    Map<String, List<Integer>> unlinkBatchTrajectoriesFromStudy(Integer studyId, List<Integer> trajectoryIds);
+    void unlinkBatchTrajectoriesFromStudy(Integer studyId, List<Integer> trajectoryIds);
 
     void unlinkAllTrajectoriesFromStudy(Integer studyId);
 

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/impl/TrajectoryServiceImpl.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/impl/TrajectoryServiceImpl.java
@@ -70,7 +70,7 @@ public class TrajectoryServiceImpl implements TrajectoryService {
     @Transactional
     @Override
     public TrajectoryEntity processLoadTrajectory(String area, String trajectoryToUse, String horizon, Integer studyId) throws IOException {
-      return saveLoadTrajectoriesInDb(area, trajectoryToUse, horizon, studyId);
+        return saveLoadTrajectoriesInDb(area, trajectoryToUse, horizon, studyId);
     }
 
     /**
@@ -108,7 +108,7 @@ public class TrajectoryServiceImpl implements TrajectoryService {
         // Build and normalize the trajectory path
         Path trajectoryPath = buildTrajectoryPath(trajectoryToUse);
 
-        
+
         // Try to find existing trajectory
         Optional<TrajectoryEntity> existingTrajectoryOpt = trajectoryRepository
                 .findFirstByFileNameAndHorizonAndAreaOrderByVersionDesc(trajectoryToUse, horizon, area);
@@ -119,12 +119,11 @@ public class TrajectoryServiceImpl implements TrajectoryService {
                     || (area.equals(OTHER_AREA)
                     && isSameVersionOfOtherLoadTrajectory(existingTrajectory, studyId, trajectoryPath, horizon)
             )
-            )
-            {
-                    throw BusinessException.builder()
-                            .message("Trajectory already uploaded")
-                            .httpStatus(HttpStatus.BAD_REQUEST)
-                            .build();
+            ) {
+                throw BusinessException.builder()
+                        .message("Trajectory already uploaded")
+                        .httpStatus(HttpStatus.BAD_REQUEST)
+                        .build();
 
             }
 
@@ -142,7 +141,7 @@ public class TrajectoryServiceImpl implements TrajectoryService {
         return buildAndSaveLoadTrajectory(area, horizon, trajectoryPath, newTrajectory, studyId, warningMessageEntities);
     }
 
-    private  boolean isSameVersionOfOtherLoadTrajectory(TrajectoryEntity existingTrajectory, Integer studyId, Path trajectoryPath, String horizon) {
+    private boolean isSameVersionOfOtherLoadTrajectory(TrajectoryEntity existingTrajectory, Integer studyId, Path trajectoryPath, String horizon) {
         List<String> studyAreas = areaRepository.findAllByStudyId(studyId).stream()
                 .map(a -> a.getName().toLowerCase())
                 .toList();
@@ -216,7 +215,7 @@ public class TrajectoryServiceImpl implements TrajectoryService {
                     .map(String::toLowerCase)
                     .toList();
         }
-        List<String> areaWithStudy = areaRepository.findAllByStudyId(studyId).stream().map(areaStudy->areaStudy.getName().toLowerCase()).toList();
+        List<String> areaWithStudy = areaRepository.findAllByStudyId(studyId).stream().map(areaStudy -> areaStudy.getName().toLowerCase()).toList();
 
         List<String> loadsFile = getValidLoadFileNamesWithHorizon(trajectoryPath, area, horizon, listCustomLoadFilesAlreadyChoosed, areaWithStudy);
         if (loadsFile.isEmpty()) {
@@ -625,6 +624,37 @@ public class TrajectoryServiceImpl implements TrajectoryService {
                         .build();
             }
         }
+    }
+
+    @Override
+    public Map<String, List<Integer>> unlinkBatchTrajectoriesFromStudy(Integer studyId, List<Integer> trajectoryIds) {
+        if (trajectoryIds == null || trajectoryIds.isEmpty()) {
+            throw BusinessException.builder()
+                    .message("trajectoryIds must not be empty")
+                    .httpStatus(HttpStatus.BAD_REQUEST)
+                    .build();
+        }
+
+        var success = new ArrayList<Integer>();
+        var failed = new ArrayList<Integer>();
+
+        trajectoryIds.stream()
+                .filter(Objects::nonNull)
+                .distinct()
+                .forEach(id -> {
+                    try {
+                        unlinkTrajectoryFromStudy(id, studyId);
+                        success.add(id);
+                    } catch (BusinessException ex) {
+                        failed.add(id);
+                        log.warn("Batch detach: business error on {} ({})", id, ex.getMessage());
+                    } catch (RuntimeException ex) {
+                        failed.add(id);
+                        log.error("Batch detach: unexpected error on {}", id, ex);
+                    }
+                });
+
+        return Map.of("success", success, "failed", failed);
     }
 
     @Override

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/impl/TrajectoryServiceImpl.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/impl/TrajectoryServiceImpl.java
@@ -654,6 +654,13 @@ public class TrajectoryServiceImpl implements TrajectoryService {
                     }
                 });
 
+        if (success.isEmpty()) {
+            throw BusinessException.builder()
+                    .message("No trajectories could be deleted")
+                    .httpStatus(HttpStatus.CONFLICT)
+                    .build();
+        }
+
         return Map.of("success", success, "failed", failed);
     }
 

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/impl/TrajectoryServiceImpl.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/impl/TrajectoryServiceImpl.java
@@ -627,41 +627,26 @@ public class TrajectoryServiceImpl implements TrajectoryService {
     }
 
     @Override
-    public Map<String, List<Integer>> unlinkBatchTrajectoriesFromStudy(Integer studyId, List<Integer> trajectoryIds) {
-        if (trajectoryIds == null || trajectoryIds.isEmpty()) {
+    @Transactional
+    public void unlinkBatchTrajectoriesFromStudy(Integer studyId, List<Integer> trajectoryIds) {
+        Objects.requireNonNull(trajectoryIds);
+
+        var ids = trajectoryIds.stream().filter(Objects::nonNull).distinct().toList();
+        if (ids.isEmpty()) {
             throw BusinessException.builder()
                     .message("trajectoryIds must not be empty")
                     .httpStatus(HttpStatus.BAD_REQUEST)
                     .build();
         }
 
-        var success = new ArrayList<Integer>();
-        var failed = new ArrayList<Integer>();
-
-        trajectoryIds.stream()
-                .filter(Objects::nonNull)
-                .distinct()
-                .forEach(id -> {
-                    try {
-                        unlinkTrajectoryFromStudy(id, studyId);
-                        success.add(id);
-                    } catch (BusinessException ex) {
-                        failed.add(id);
-                        log.warn("Batch detach: business error on {} ({})", id, ex.getMessage());
-                    } catch (RuntimeException ex) {
-                        failed.add(id);
-                        log.error("Batch detach: unexpected error on {}", id, ex);
-                    }
-                });
-
-        if (success.isEmpty()) {
+        var deleted = studyTrajectoryRepository.deleteByStudyIdAndTrajectoryIds(studyId, ids);
+        if (deleted != ids.size()) {
             throw BusinessException.builder()
-                    .message("No trajectories could be deleted")
+                    .message("Batch detach of trajectories {0} failed")
+                    .errorMessageArguments(List.of(ids.toString()))
                     .httpStatus(HttpStatus.CONFLICT)
                     .build();
         }
-
-        return Map.of("success", success, "failed", failed);
     }
 
     @Override

--- a/src/test/java/com/rte_france/antares/datamanager_back/controller/TrajectoryControllerTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/controller/TrajectoryControllerTest.java
@@ -23,7 +23,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import java.util.List;
-import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -306,31 +305,36 @@ class TrajectoryControllerTest {
                 .andExpect(status().isOk());
     }
 
-    // In src/test/java/com/rte_france/antares/datamanager_back/controller/TrajectoryControllerTest.java
-
     @Test
-    void unlinkBatch_shouldReturnSuccessAndFailedLists() throws Exception {
+    void unlinkBatch_returnsNoContentOnSuccess() throws Exception {
         Integer studyId = 1;
-        var trajectoryIds = List.of(1, 2, 3);
-        var response = Map.of(
-                "success", List.of(1, 2),
-                "failed", List.of(3)
-        );
+        var ids = List.of(1, 2, 3);
 
-        when(trajectoryServiceImpl.unlinkBatchTrajectoriesFromStudy(eq(studyId), eq(trajectoryIds)))
-                .thenReturn(response);
+        doNothing().when(trajectoryServiceImpl)
+                .unlinkBatchTrajectoriesFromStudy(studyId, ids);
 
         this.mockMvc.perform(post("/v1/trajectory/detach/batch")
                         .param("studyId", studyId.toString())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("[1,2,3]")
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").isArray())
-                .andExpect(jsonPath("$.failed").isArray())
-                .andExpect(jsonPath("$.success[0]").value(1))
-                .andExpect(jsonPath("$.success[1]").value(2))
-                .andExpect(jsonPath("$.failed[0]").value(3));
+                        .content("[1,2,3]"))
+                .andExpect(status().isNoContent());
     }
 
+    @Test
+    void unlinkBatch_returnsConflictOnBusinessException() throws Exception {
+        Integer studyId = 1;
+
+        doThrow(BusinessException.builder()
+                .message("Batch detach failed")
+                .httpStatus(HttpStatus.CONFLICT)
+                .build())
+                .when(trajectoryServiceImpl)
+                .unlinkBatchTrajectoriesFromStudy(eq(studyId), eq(List.of(1, 2, 3)));
+
+        this.mockMvc.perform(post("/v1/trajectory/detach/batch")
+                        .param("studyId", studyId.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("[1,2,3]"))
+                .andExpect(status().isConflict());
+    }
 }

--- a/src/test/java/com/rte_france/antares/datamanager_back/controller/TrajectoryControllerTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/controller/TrajectoryControllerTest.java
@@ -23,6 +23,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -304,4 +305,32 @@ class TrajectoryControllerTest {
                         .contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk());
     }
+
+    // In src/test/java/com/rte_france/antares/datamanager_back/controller/TrajectoryControllerTest.java
+
+    @Test
+    void unlinkBatch_shouldReturnSuccessAndFailedLists() throws Exception {
+        Integer studyId = 1;
+        var trajectoryIds = List.of(1, 2, 3);
+        var response = Map.of(
+                "success", List.of(1, 2),
+                "failed", List.of(3)
+        );
+
+        when(trajectoryServiceImpl.unlinkBatchTrajectoriesFromStudy(eq(studyId), eq(trajectoryIds)))
+                .thenReturn(response);
+
+        this.mockMvc.perform(post("/v1/trajectory/detach/batch")
+                        .param("studyId", studyId.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("[1,2,3]")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").isArray())
+                .andExpect(jsonPath("$.failed").isArray())
+                .andExpect(jsonPath("$.success[0]").value(1))
+                .andExpect(jsonPath("$.success[1]").value(2))
+                .andExpect(jsonPath("$.failed[0]").value(3));
+    }
+
 }

--- a/src/test/java/com/rte_france/antares/datamanager_back/repository/StudyTrajectoryRepositoryTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/repository/StudyTrajectoryRepositoryTest.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -39,5 +40,26 @@ class StudyTrajectoryRepositoryTest {
         assertThat(result)
                 .isNotNull()
                 .isEmpty();
+    }
+
+    @Test
+    @Transactional
+    void deleteByStudyIdAndTrajectoryIds_deletesExpectedRows() {
+        var studyId = 1;
+
+        var before = studyTrajectoryRepository.findById_ScenarioId(studyId);
+        assertThat(before).isNotEmpty();
+
+        var toDelete = before.stream()
+                .limit(2)
+                .map(e -> e.getId().getTrajectoryId())
+                .toList();
+
+        var deleted = studyTrajectoryRepository.deleteByStudyIdAndTrajectoryIds(studyId, toDelete);
+        assertThat(deleted).isEqualTo(toDelete.size());
+
+        var after = studyTrajectoryRepository.findById_ScenarioId(studyId);
+        var remainingIds = after.stream().map(e -> e.getId().getTrajectoryId()).toList();
+        assertThat(remainingIds).doesNotContainAnyElementsOf(toDelete);
     }
 }

--- a/src/test/java/com/rte_france/antares/datamanager_back/repository/StudyTrajectoryRepositoryTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/repository/StudyTrajectoryRepositoryTest.java
@@ -60,6 +60,7 @@ class StudyTrajectoryRepositoryTest {
 
         var after = studyTrajectoryRepository.findById_ScenarioId(studyId);
         var remainingIds = after.stream().map(e -> e.getId().getTrajectoryId()).toList();
+        assertThat(remainingIds).isNotEmpty();
         assertThat(remainingIds).doesNotContainAnyElementsOf(toDelete);
     }
 }

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/TrajectoryServiceImplAdditionalTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/TrajectoryServiceImplAdditionalTest.java
@@ -292,4 +292,42 @@ class TrajectoryServiceImplAdditionalTest {
         assertEquals("No links found", ex.getMessage());
         assertEquals(HttpStatus.BAD_REQUEST, ex.getHttpStatus());
     }
+
+    @Test
+    void unlinkBatchTrajectoriesFromStudy_shouldReturnSuccessAndFailedLists() {
+        var studyId = 1;
+        var trajectoryIds = List.of(1, 2, 3);
+
+        when(trajectoryRepository.findById(any()))
+                .thenAnswer(inv -> {
+                    var id = (Integer) inv.getArgument(0);
+                    return Optional.of(
+                            TrajectoryEntity.builder()
+                                    .id(id)
+                                    .type(TrajectoryType.LINK.name())
+                                    .build()
+                    );
+                });
+
+        when(studyTrajectoryRepository.findById(any()))
+                .thenAnswer(inv -> {
+                    var key = (StudyTrajectoryKey) inv.getArgument(0);
+                    if (Objects.equals(key.getTrajectoryId(), 3)) {
+                        return Optional.empty();
+                    }
+                    return Optional.of(
+                            StudyTrajectoryEntity.builder()
+                                    .id(key)
+                                    .build()
+                    );
+                });
+
+        var result = trajectoryService.unlinkBatchTrajectoriesFromStudy(studyId, trajectoryIds);
+
+        assertEquals(List.of(1, 2), result.get("success"));
+        assertEquals(List.of(3), result.get("failed"));
+
+        verify(studyTrajectoryRepository, times(2)).delete(any(StudyTrajectoryEntity.class));
+    }
+
 }

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/TrajectoryServiceImplAdditionalTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/TrajectoryServiceImplAdditionalTest.java
@@ -294,40 +294,52 @@ class TrajectoryServiceImplAdditionalTest {
     }
 
     @Test
-    void unlinkBatchTrajectoriesFromStudy_shouldReturnSuccessAndFailedLists() {
+    void unlinkBatch_success_whenDeletedCountEqualsRequested() {
         var studyId = 1;
         var trajectoryIds = List.of(1, 2, 3);
 
-        when(trajectoryRepository.findById(any()))
-                .thenAnswer(inv -> {
-                    var id = (Integer) inv.getArgument(0);
-                    return Optional.of(
-                            TrajectoryEntity.builder()
-                                    .id(id)
-                                    .type(TrajectoryType.LINK.name())
-                                    .build()
-                    );
-                });
+        when(studyTrajectoryRepository.deleteByStudyIdAndTrajectoryIds(studyId, List.of(1,2,3)))
+                .thenReturn(3);
 
-        when(studyTrajectoryRepository.findById(any()))
-                .thenAnswer(inv -> {
-                    var key = (StudyTrajectoryKey) inv.getArgument(0);
-                    if (Objects.equals(key.getTrajectoryId(), 3)) {
-                        return Optional.empty();
-                    }
-                    return Optional.of(
-                            StudyTrajectoryEntity.builder()
-                                    .id(key)
-                                    .build()
-                    );
-                });
+        assertDoesNotThrow(() ->
+                trajectoryService.unlinkBatchTrajectoriesFromStudy(studyId, trajectoryIds)
+        );
 
-        var result = trajectoryService.unlinkBatchTrajectoriesFromStudy(studyId, trajectoryIds);
-
-        assertEquals(List.of(1, 2), result.get("success"));
-        assertEquals(List.of(3), result.get("failed"));
-
-        verify(studyTrajectoryRepository, times(2)).delete(any(StudyTrajectoryEntity.class));
+        verify(studyTrajectoryRepository).deleteByStudyIdAndTrajectoryIds(studyId, List.of(1,2,3));
     }
 
+    @Test
+    void unlinkBatch_throwsBusinessConflict_whenPartialDeletion() {
+        var studyId = 1;
+        var trajectoryIds = List.of(1, 2, 3);
+
+        when(studyTrajectoryRepository.deleteByStudyIdAndTrajectoryIds(studyId, List.of(1,2,3)))
+                .thenReturn(2);
+
+        var ex = assertThrows(BusinessException.class, () ->
+                trajectoryService.unlinkBatchTrajectoriesFromStudy(studyId, trajectoryIds)
+        );
+        assertEquals(HttpStatus.CONFLICT, ex.getHttpStatus());
+    }
+
+    @Test
+    void unlinkBatch_throwsBadRequest_whenEmptyAfterFilter() {
+        var studyId = 1;
+
+        var ex = assertThrows(BusinessException.class, () ->
+                trajectoryService.unlinkBatchTrajectoriesFromStudy(studyId, Arrays.asList(null, null))
+        );
+        assertEquals(HttpStatus.BAD_REQUEST, ex.getHttpStatus());
+
+        verifyNoInteractions(studyTrajectoryRepository);
+    }
+
+    @Test
+    void unlinkBatch_throwsNPE_whenListIsNull() {
+        var studyId = 1;
+        assertThrows(NullPointerException.class, () ->
+                trajectoryService.unlinkBatchTrajectoriesFromStudy(studyId, null)
+        );
+        verifyNoInteractions(studyTrajectoryRepository);
+    }
 }


### PR DESCRIPTION
https://gopro-tickets.rte-france.com/browse/ANT-3698
- Added a new endpoint detach/batch
- takes the study id as param and a list of trajectory ids as the body
- Returns a business exception if one of them cannot be deleted. Success otherwise