### PR TITLE
Fix/ANT-3688 - (Ano) Duplicate warning generation with missing area

### DIFF
--- a/src/main/java/com/rte_france/antares/datamanager_back/service/impl/LoadFileProcessorServiceImpl.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/impl/LoadFileProcessorServiceImpl.java
@@ -21,6 +21,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -88,21 +89,46 @@ public class LoadFileProcessorServiceImpl implements LoadFileProcessorService {
     /**
      * Main logic for both checkForMissingLoadFiles and checkForMissingLoadByAreaFromDb
      */
-    private Set<WarningMessageEntity> checkMissingLoad(Integer studyId, String userNni,
-                                                       TrajectoryEntity trajectory,
-                                                       LoadChecker loadChecker) {
-        List<String> areasWithoutTrajectory = getAreasLoadWithoutTrajectorySelected(studyId);
-
-        List<String> missingLoadFiles = areasWithoutTrajectory.stream()
-                .filter(area -> !loadChecker.exists(area.toLowerCase()))
+    public List<String> getAreasLoadWithoutTrajectorySelected(Integer studyId) {
+        List<String> studyAreas = areaRepository.findAllByStudyId(studyId).stream()
+                .map(AreaEntity::getName)
+                .map(n -> n == null ? null : n.trim().toUpperCase(Locale.ROOT))
+                .distinct()
                 .toList();
 
-        if (!areasWithoutTrajectory.isEmpty() && missingLoadFiles.size() == areasWithoutTrajectory.size()) {
+        Set<String> customAreas = trajectoryRepository.findByTypeAndStudyId(TrajectoryType.LOAD.name(), studyId).stream()
+                .map(TrajectoryEntity::getLoadArea)
+                .filter(Objects::nonNull)
+                .map(n -> n.trim().toUpperCase(Locale.ROOT))
+                .filter(a -> !TrajectoryServiceImpl.OTHER_AREA.equals(a))
+                .collect(Collectors.toSet());
+
+        return studyAreas.stream()
+                .filter(a -> !customAreas.contains(a))
+                .toList();
+    }
+
+
+    private Set<WarningMessageEntity> checkMissingLoad(Integer studyId,
+                                                       String userNni,
+                                                       TrajectoryEntity trajectory,
+                                                       LoadChecker loadChecker) {
+        List<String> impactedAreas = getAreasLoadWithoutTrajectorySelected(studyId).stream()
+                .map(n -> n == null ? null : n.trim().toUpperCase(Locale.ROOT))
+                .toList();
+
+        LoadChecker normalizedChecker = area -> loadChecker.exists(area == null ? null : area.trim().toUpperCase(Locale.ROOT));
+
+        List<String> missingLoadFiles = impactedAreas.stream()
+                .filter(area -> !normalizedChecker.exists(area))
+                .toList();
+
+        if (!impactedAreas.isEmpty() && missingLoadFiles.size() == impactedAreas.size()) {
             throw BusinessException.builder()
                     .message("Missing file(s) for area(s) {0} in LOAD Other areas trajectory {1}\n" +
                             "Please re import trajectory {1} to complete area(s)")
                     .errorMessageArguments(Arrays.asList(
-                            String.join(", ", areasWithoutTrajectory),
+                            String.join(", ", impactedAreas),
                             trajectory.getFileName()
                     ))
                     .httpStatus(HttpStatus.BAD_REQUEST)
@@ -111,7 +137,8 @@ public class LoadFileProcessorServiceImpl implements LoadFileProcessorService {
 
         Set<WarningMessageEntity> warningMessages = new HashSet<>();
         if (!missingLoadFiles.isEmpty()) {
-            warningService.addWarning(warningMessages,
+            warningService.addWarning(
+                    warningMessages,
                     Arrays.asList(String.join(", ", missingLoadFiles), trajectory.getFileName()),
                     WarningCode.LOAD_MISSING_TRAJECTORY_FOR_AREAS,
                     studyId,
@@ -121,21 +148,6 @@ public class LoadFileProcessorServiceImpl implements LoadFileProcessorService {
         }
 
         return warningMessages;
-    }
-
-    public List<String> getAreasLoadWithoutTrajectorySelected(Integer studyId) {
-        List<String> studyAreas = areaRepository.findAllByStudyId(studyId).stream()
-                .map(AreaEntity::getName)
-                .toList();
-
-        List<String> areasWithTrajectory = trajectoryRepository.findByTypeAndStudyId(TrajectoryType.LOAD.name(), studyId)
-                .stream()
-                .map(TrajectoryEntity::getLoadArea)
-                .toList();
-
-        return studyAreas.stream()
-                .filter(area -> !areasWithTrajectory.contains(area))
-                .toList();
     }
 
     /**

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/impl/LoadFileProcessorServiceImpl.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/impl/LoadFileProcessorServiceImpl.java
@@ -8,6 +8,7 @@ import com.rte_france.antares.datamanager_back.repository.TrajectoryRepository;
 import com.rte_france.antares.datamanager_back.repository.model.*;
 import com.rte_france.antares.datamanager_back.service.LoadFileProcessorService;
 import com.rte_france.antares.datamanager_back.service.WarningService;
+import com.rte_france.antares.datamanager_back.util.Utils;
 import com.rte_france.antares.datamanager_back.util.timeseries_manager.TimeSeriesMatrix;
 import com.rte_france.antares.datamanager_back.util.timeseries_manager.TimeSeriesReader;
 import com.rte_france.antares.datamanager_back.util.timeseries_manager.TimeSeriesWriter;
@@ -92,14 +93,14 @@ public class LoadFileProcessorServiceImpl implements LoadFileProcessorService {
     public List<String> getAreasLoadWithoutTrajectorySelected(Integer studyId) {
         List<String> studyAreas = areaRepository.findAllByStudyId(studyId).stream()
                 .map(AreaEntity::getName)
-                .map(n -> n == null ? null : n.trim().toUpperCase(Locale.ROOT))
+                .map(Utils::normalize)
                 .distinct()
                 .toList();
 
         Set<String> customAreas = trajectoryRepository.findByTypeAndStudyId(TrajectoryType.LOAD.name(), studyId).stream()
                 .map(TrajectoryEntity::getLoadArea)
                 .filter(Objects::nonNull)
-                .map(n -> n.trim().toUpperCase(Locale.ROOT))
+                .map(Utils::normalize)
                 .filter(a -> !TrajectoryServiceImpl.OTHER_AREA.equals(a))
                 .collect(Collectors.toSet());
 
@@ -114,10 +115,10 @@ public class LoadFileProcessorServiceImpl implements LoadFileProcessorService {
                                                        TrajectoryEntity trajectory,
                                                        LoadChecker loadChecker) {
         List<String> impactedAreas = getAreasLoadWithoutTrajectorySelected(studyId).stream()
-                .map(n -> n == null ? null : n.trim().toUpperCase(Locale.ROOT))
+                .map(Utils::normalize)
                 .toList();
 
-        LoadChecker normalizedChecker = area -> loadChecker.exists(area == null ? null : area.trim().toUpperCase(Locale.ROOT));
+        LoadChecker normalizedChecker = area -> loadChecker.exists(Utils.normalize(area));
 
         List<String> missingLoadFiles = impactedAreas.stream()
                 .filter(area -> !normalizedChecker.exists(area))
@@ -161,15 +162,24 @@ public class LoadFileProcessorServiceImpl implements LoadFileProcessorService {
      * Returns a LoadChecker that checks for file existence in the database.
      * If the file does not exist, it creates a new LoadEntity and saves it.
      */
-    /**
-     * Returns a LoadChecker that checks for file existence in the DB.
-     */
     private LoadChecker getFileCheckerByDatabase(String horizon, TrajectoryEntity trajectory, Integer studyId) {
-       //TODO FIX
-        return area -> loadRepository.existsByFileName(
-                "load_" + area.toLowerCase() + "_" + horizon + ".txt"
-        );
+        if (trajectory.getLoadEntities() != null && !trajectory.getLoadEntities().isEmpty()) {
+            Set<String> areasInThisOthers = trajectory.getLoadEntities().stream()
+                    .map(LoadEntity::getArea)
+                    .filter(Objects::nonNull)
+                    .map(Utils::normalize)
+                    .collect(Collectors.toSet());
+
+            return area -> areasInThisOthers.contains(Utils.normalize(area));
+        }
+
+        String trajFileName = trajectory.getFileName();
+        return area -> {
+            String fn = "load_" + Utils.normalize(area) + "_" + horizon + ".txt";
+            return loadRepository.findByFileNameAndTrajectoryFileName(fn, trajFileName).isPresent();
+        };
     }
+
 
     @FunctionalInterface
     private interface LoadChecker {

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/impl/LoadFileProcessorServiceImpl.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/impl/LoadFileProcessorServiceImpl.java
@@ -37,6 +37,8 @@ public class LoadFileProcessorServiceImpl implements LoadFileProcessorService {
     private final WarningService warningService;
     private final LoadRepository loadRepository;
 
+    private static final String OTHER_AREA = "OTHERS";
+
     /**
      * Saves a time series matrix read from the given path to NAS with a unique filename.
      *
@@ -101,7 +103,7 @@ public class LoadFileProcessorServiceImpl implements LoadFileProcessorService {
                 .map(TrajectoryEntity::getLoadArea)
                 .filter(Objects::nonNull)
                 .map(Utils::normalize)
-                .filter(a -> !TrajectoryServiceImpl.OTHER_AREA.equals(a))
+                .filter(a -> !OTHER_AREA.equals(a))
                 .collect(Collectors.toSet());
 
         return studyAreas.stream()

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/impl/TrajectoryServiceImpl.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/impl/TrajectoryServiceImpl.java
@@ -458,21 +458,6 @@ public class TrajectoryServiceImpl implements TrajectoryService {
                                 .httpStatus(HttpStatus.BAD_REQUEST)
                                 .build());
 
-        if (TrajectoryType.LOAD.equals(type) && OTHER_AREA.equals(trajectory.getLoadArea())) {
-            var userNni = userService.getCurrentUserDetails().getNni();
-            var trajectoryPath = buildTrajectoryPath(trajectory.getFileName());
-            var warnings = loadFileProcessorService.checkForMissingLoadFiles(
-                    trajectoryPath,
-                    trajectory.getHorizon(),
-                    studyId,
-                    userNni,
-                    trajectory
-            );
-            warnings.forEach(warning -> warning.setTrajectory(trajectory));
-            warnings.forEach(warning -> warning.setStudy(study));
-            warningRepository.saveAll(warnings);
-        }
-
         Optional<StudyTrajectoryEntity> existingLink = Optional.empty();
         if (!TrajectoryType.LOAD.equals(type) && study.getStudyTrajectoryEntities() != null) {
             existingLink = study.getStudyTrajectoryEntities().stream()

--- a/src/main/java/com/rte_france/antares/datamanager_back/util/Utils.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/util/Utils.java
@@ -8,7 +8,6 @@ import com.google.common.hash.Hashing;
 import com.rte_france.antares.datamanager_back.dto.TrajectoryType;
 import com.rte_france.antares.datamanager_back.exception.BusinessException;
 import com.rte_france.antares.datamanager_back.exception.TechnicalException;
-import com.rte_france.antares.datamanager_back.repository.model.AreaEntity;
 import com.rte_france.antares.datamanager_back.repository.model.TrajectoryEntity;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
@@ -31,6 +30,7 @@ import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
@@ -335,7 +335,6 @@ public class Utils {
 
     /**
      * Extracts the area identifier from a given file name.
-     *
      * The expected file name format is "load_AREA_HORIZON.txt", where "AREA" represents the area identifier.
      * If the file name does not match the expected format or "load" is not the prefix, the method returns null.
      *
@@ -351,4 +350,13 @@ public class Utils {
         return null;
     }
 
+    /**
+     * Normalize a string (to upper case)
+     * @param s string
+     * @return normalized string s
+     */
+    public static String normalize(String s) {
+        Objects.requireNonNull(s);
+        return s.trim().toUpperCase(Locale.ROOT);
+    }
 }

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/LoadFileProcessorServiceImplTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/LoadFileProcessorServiceImplTest.java
@@ -5,10 +5,7 @@ import com.rte_france.antares.datamanager_back.exception.BusinessException;
 import com.rte_france.antares.datamanager_back.repository.AreaRepository;
 import com.rte_france.antares.datamanager_back.repository.LoadRepository;
 import com.rte_france.antares.datamanager_back.repository.TrajectoryRepository;
-import com.rte_france.antares.datamanager_back.repository.model.AreaEntity;
-import com.rte_france.antares.datamanager_back.repository.model.TrajectoryEntity;
-import com.rte_france.antares.datamanager_back.repository.model.WarningCode;
-import com.rte_france.antares.datamanager_back.repository.model.WarningMessageEntity;
+import com.rte_france.antares.datamanager_back.repository.model.*;
 import com.rte_france.antares.datamanager_back.service.impl.LoadFileProcessorServiceImpl;
 import com.rte_france.antares.datamanager_back.service.impl.NasFileService;
 import com.rte_france.antares.datamanager_back.service.impl.UserService;
@@ -25,9 +22,7 @@ import org.mockito.MockitoAnnotations;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -218,6 +213,82 @@ class LoadFileProcessorServiceImplTest {
         assertTrue(result.isEmpty());
         verify(warningService, never()).getMessage(anyString(), any());
         verify(warningService, never()).addWarning(any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void checkForMissingLoadByAreaFromDb_usesOnlyThisTrajectoryLoadEntities() {
+        // Given
+        var studyAreas = List.of("BE", "DE");
+        var areaEntities = studyAreas.stream()
+                .map(n -> AreaEntity.builder().name(n).build())
+                .toList();
+        var beLoad = LoadEntity.builder().area("be").fileName("load_BE_" + horizon + ".txt").build();
+
+        // When
+        when(areaRepository.findAllByStudyId(studyId)).thenReturn(areaEntities);
+        when(trajectoryRepository.findByTypeAndStudyId(eq("LOAD"), eq(studyId)))
+                .thenReturn(List.of());
+
+        trajectory.setLoadEntities(new HashSet<>(List.of(beLoad)));
+
+        Set<WarningMessageEntity> result = loadFileProcessorService.checkForMissingLoadByAreaFromDb(
+                horizon, studyId, userNni, trajectory
+        );
+
+        // Then
+        verify(warningService).addWarning(
+                eq(result),
+                argThat(args -> args.size() == 2 &&
+                        args.get(0).equals("DE") &&
+                        args.get(1).equals(trajectory.getFileName())),
+                eq(WarningCode.LOAD_MISSING_TRAJECTORY_FOR_AREAS),
+                eq(studyId),
+                eq(userNni),
+                eq(trajectory)
+        );
+
+        verify(loadRepository, never()).findByFileNameAndTrajectoryFileName(anyString(), anyString());
+    }
+
+    @Test
+    void checkForMissingLoadByAreaFromDb_fallbacksToDbWhenNoLoadEntities() {
+        // Given
+        var studyAreas = List.of("BE", "DE");
+        var areaEntities = studyAreas.stream()
+                .map(n -> AreaEntity.builder().name(n).build())
+                .toList();
+
+        // When
+        when(areaRepository.findAllByStudyId(studyId)).thenReturn(areaEntities);
+        when(trajectoryRepository.findByTypeAndStudyId(eq("LOAD"), eq(studyId)))
+                .thenReturn(List.of());
+
+        trajectory.setLoadEntities(Collections.emptySet());
+        trajectory.setFileName("OTHERS");
+
+        when(loadRepository.findByFileNameAndTrajectoryFileName(
+                eq("load_BE_" + horizon + ".txt"), eq("OTHERS"))).thenReturn(Optional.of(LoadEntity.builder().build()));
+        when(loadRepository.findByFileNameAndTrajectoryFileName(
+                eq("load_DE_" + horizon + ".txt"), eq("OTHERS"))).thenReturn(Optional.empty());
+
+        Set<WarningMessageEntity> result = loadFileProcessorService.checkForMissingLoadByAreaFromDb(
+                horizon, studyId, userNni, trajectory
+        );
+
+        // Then
+        verify(warningService).addWarning(
+                eq(result),
+                argThat(args -> args.size() == 2 &&
+                        args.get(0).equals("DE") &&
+                        args.get(1).equals("OTHERS")),
+                eq(WarningCode.LOAD_MISSING_TRAJECTORY_FOR_AREAS),
+                eq(studyId),
+                eq(userNni),
+                eq(trajectory)
+        );
+
+        verify(loadRepository).findByFileNameAndTrajectoryFileName("load_BE_" + horizon + ".txt", "OTHERS");
+        verify(loadRepository).findByFileNameAndTrajectoryFileName("load_DE_" + horizon + ".txt", "OTHERS");
     }
 
 }

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/LoadFileProcessorServiceImplTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/LoadFileProcessorServiceImplTest.java
@@ -226,7 +226,7 @@ class LoadFileProcessorServiceImplTest {
 
         // When
         when(areaRepository.findAllByStudyId(studyId)).thenReturn(areaEntities);
-        when(trajectoryRepository.findByTypeAndStudyId(eq("LOAD"), eq(studyId)))
+        when(trajectoryRepository.findByTypeAndStudyId("LOAD", studyId))
                 .thenReturn(List.of());
 
         trajectory.setLoadEntities(new HashSet<>(List.of(beLoad)));
@@ -260,16 +260,16 @@ class LoadFileProcessorServiceImplTest {
 
         // When
         when(areaRepository.findAllByStudyId(studyId)).thenReturn(areaEntities);
-        when(trajectoryRepository.findByTypeAndStudyId(eq("LOAD"), eq(studyId)))
+        when(trajectoryRepository.findByTypeAndStudyId("LOAD", studyId))
                 .thenReturn(List.of());
 
         trajectory.setLoadEntities(Collections.emptySet());
         trajectory.setFileName("OTHERS");
 
         when(loadRepository.findByFileNameAndTrajectoryFileName(
-                eq("load_BE_" + horizon + ".txt"), eq("OTHERS"))).thenReturn(Optional.of(LoadEntity.builder().build()));
+                "load_BE_" + horizon + ".txt", "OTHERS")).thenReturn(Optional.of(LoadEntity.builder().build()));
         when(loadRepository.findByFileNameAndTrajectoryFileName(
-                eq("load_DE_" + horizon + ".txt"), eq("OTHERS"))).thenReturn(Optional.empty());
+                "load_DE_" + horizon + ".txt", "OTHERS")).thenReturn(Optional.empty());
 
         Set<WarningMessageEntity> result = loadFileProcessorService.checkForMissingLoadByAreaFromDb(
                 horizon, studyId, userNni, trajectory

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/TrajectoryServiceImplTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/TrajectoryServiceImplTest.java
@@ -863,7 +863,7 @@ class TrajectoryServiceImplTest {
     }
 
     @Test
-    void linkTrajectoryToStudy_shouldCheckForMissingLoadFilesAndSaveWarnings_whenLoadTypeAndOtherArea() throws IOException {
+    void linkTrajectoryToStudy_shouldComputeMissingLoadFromDbAndSaveWarnings_whenLoadOtherArea() throws IOException {
         var trajectoryId = 1;
         var studyId = 2;
         var userNni = "user";
@@ -886,18 +886,18 @@ class TrajectoryServiceImplTest {
         when(studyRepository.findById(studyId)).thenReturn(Optional.of(study));
         when(trajectoryRepository.findById(trajectoryId)).thenReturn(Optional.of(trajectory));
         when(userService.getCurrentUserDetails()).thenReturn(UserInfoDto.builder().nni(userNni).build());
-        when(antaressDataManagerProperties.getNasDirectory()).thenReturn("/tmp");
-        when(antaressDataManagerProperties.getTrajectoryFilePath()).thenReturn("");
-        when(antaressDataManagerProperties.getLoadDirectory()).thenReturn("");
-        when(loadFileProcessorService.checkForMissingLoadFiles(any(), eq(horizon), eq(studyId), eq(userNni), eq(trajectory)))
+        when(studyTrajectoryRepository.save(any()))
+                .thenReturn(StudyTrajectoryEntity.builder().trajectory(trajectory).build());
+
+        when(loadFileProcessorService.checkForMissingLoadByAreaFromDb(horizon, studyId, userNni, trajectory))
                 .thenReturn(warnings);
-        when(studyTrajectoryRepository.save(any())).thenReturn(StudyTrajectoryEntity.builder().trajectory(trajectory).build());
 
         trajectoryService.linkTrajectoryToStudy(trajectoryId, studyId, TrajectoryType.LOAD);
 
         assertTrue(warnings.stream().allMatch(w -> w.getTrajectory() == trajectory));
-        assertTrue(warnings.stream().allMatch(w -> w.getStudy() == study));
         verify(warningRepository).saveAll(warnings);
-        verify(loadFileProcessorService).checkForMissingLoadFiles(any(), eq(horizon), eq(studyId), eq(userNni), eq(trajectory));
+        verify(loadFileProcessorService).checkForMissingLoadByAreaFromDb(horizon, studyId, userNni, trajectory);
+        verify(loadFileProcessorService, never()).checkForMissingLoadFiles(any(), any(), any(), any(), any());
     }
+
 }


### PR DESCRIPTION
Warnings in /attach are generated twice:

- in linkTrajectoryToStudy with file system, and in checkTrajectoryCoherence with DB. This is what causes two warnings to be generated.
- getFileCheckerByDatabase was checking in all the repository, which is why some areas were not including in the missing message

Fix: 

- Removed the file system check

- Corrected the db check to include all study areas and not skip the ones that already have a trajectory

- Normalized the areas because toLowerCase was not being used everywhere

- Fixed getFileCheckerByDatabase to not check any file in the DB

