### PR TITLE
Feat/ ANT-3674 - Add thermal capacity and common params processing into json

### DIFF
--- a/src/main/java/com/rte_france/antares/datamanager_back/dto/ThermalClusterPropertiesDto.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/dto/ThermalClusterPropertiesDto.java
@@ -1,5 +1,6 @@
 package com.rte_france.antares.datamanager_back.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.NoArgsConstructor;
@@ -11,80 +12,41 @@ import lombok.Builder;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder(toBuilder = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ThermalClusterPropertiesDto {
-  private boolean enabled;
-  private int unitCount;
-  private double nominalCapacity;
+  private Boolean enabled;
+  private Integer unitCount;
+  private Double nominalCapacity;
   private String group;
   private String genTs;
-  private double minStablePower;
-  private int minUpTime;
-  private int minDownTime;
-  private boolean mustRun;
-  private double spinning;
-  private double volatilityForced;
-  private double volatilityPlanned;
+  private Double minStablePower;
+  private Integer minUpTime;
+  private Integer minDownTime;
+  private Boolean mustRun;
+  private Double spinning;
+  private Double volatilityForced;
+  private Double volatilityPlanned;
   private String lawForced;
   private String lawPlanned;
-  private double marginalCost;
-  private double spreadCost;
-  private double fixedCost;
-  private double startupCost;
-  private double marketBidCost;
-  private double co2;
-  private double nh3;
-  private double so2;
-  private double nox;
-  private double pm2_5;
-  private double pm5;
-  private double pm10;
-  private double nmvoc;
-  private double op1;
-  private double op2;
-  private double op3;
-  private double op4;
-  private double op5;
+  private Double marginalCost;
+  private Double spreadCost;
+  private Double fixedCost;
+  private Double startupCost;
+  private Double marketBidCost;
+  private Double co2;
+  private Double nh3;
+  private Double so2;
+  private Double nox;
+  private Double pm2_5;
+  private Double pm5;
+  private Double pm10;
+  private Double nmvoc;
+  private Double op1;
+  private Double op2;
+  private Double op3;
+  private Double op4;
+  private Double op5;
   private String costGeneration;
-  private double efficiency;
-  private double variableOMCost;
-
-  public static ThermalClusterPropertiesDto defaults() {
-    return ThermalClusterPropertiesDto.builder()
-            .enabled(true)
-            .nominalCapacity(0)
-            .unitCount(1)
-            .group("OTHER1")
-            .genTs("use global")
-            .minStablePower(0)
-            .minUpTime(1)
-            .minDownTime(1)
-            .mustRun(false)
-            .spinning(0)
-            .volatilityForced(0)
-            .volatilityPlanned(0)
-            .lawForced("uniform")
-            .lawPlanned("uniform")
-            .marginalCost(0)
-            .spreadCost(0)
-            .fixedCost(0)
-            .startupCost(0)
-            .marketBidCost(0)
-            .co2(0)
-            .nh3(0)
-            .so2(0)
-            .nox(0)
-            .pm2_5(0)
-            .pm5(0)
-            .pm10(0)
-            .nmvoc(0)
-            .op1(0)
-            .op2(0)
-            .op3(0)
-            .op4(0)
-            .op5(0)
-            .costGeneration("set_manually")
-            .efficiency(100)
-            .variableOMCost(0)
-            .build();
-  }
+  private Double efficiency;
+  private Double variableOMCost;
 }

--- a/src/main/java/com/rte_france/antares/datamanager_back/dto/ThermalClusterPropertiesDto.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/dto/ThermalClusterPropertiesDto.java
@@ -1,0 +1,90 @@
+package com.rte_france.antares.datamanager_back.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+public class ThermalClusterPropertiesDto {
+  private boolean enabled;
+  private int unitCount;
+  private double nominalCapacity;
+  private String group;
+  private String genTs;
+  private double minStablePower;
+  private int minUpTime;
+  private int minDownTime;
+  private boolean mustRun;
+  private double spinning;
+  private double volatilityForced;
+  private double volatilityPlanned;
+  private String lawForced;
+  private String lawPlanned;
+  private double marginalCost;
+  private double spreadCost;
+  private double fixedCost;
+  private double startupCost;
+  private double marketBidCost;
+  private double co2;
+  private double nh3;
+  private double so2;
+  private double nox;
+  private double pm2_5;
+  private double pm5;
+  private double pm10;
+  private double nmvoc;
+  private double op1;
+  private double op2;
+  private double op3;
+  private double op4;
+  private double op5;
+  private String costGeneration;
+  private double efficiency;
+  private double variableOMCost;
+
+  public static ThermalClusterPropertiesDto defaults() {
+    return ThermalClusterPropertiesDto.builder()
+            .enabled(true)
+            .nominalCapacity(0)
+            .unitCount(1)
+            .group("OTHER1")
+            .genTs("use global")
+            .minStablePower(0)
+            .minUpTime(1)
+            .minDownTime(1)
+            .mustRun(false)
+            .spinning(0)
+            .volatilityForced(0)
+            .volatilityPlanned(0)
+            .lawForced("uniform")
+            .lawPlanned("uniform")
+            .marginalCost(0)
+            .spreadCost(0)
+            .fixedCost(0)
+            .startupCost(0)
+            .marketBidCost(0)
+            .co2(0)
+            .nh3(0)
+            .so2(0)
+            .nox(0)
+            .pm2_5(0)
+            .pm5(0)
+            .pm10(0)
+            .nmvoc(0)
+            .op1(0)
+            .op2(0)
+            .op3(0)
+            .op4(0)
+            .op5(0)
+            .costGeneration("SET_MANUALLY")
+            .efficiency(100)
+            .variableOMCost(0)
+            .build();
+  }
+}

--- a/src/main/java/com/rte_france/antares/datamanager_back/dto/ThermalClusterPropertiesDto.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/dto/ThermalClusterPropertiesDto.java
@@ -82,7 +82,7 @@ public class ThermalClusterPropertiesDto {
             .op3(0)
             .op4(0)
             .op5(0)
-            .costGeneration("SET_MANUALLY")
+            .costGeneration("set_manually")
             .efficiency(100)
             .variableOMCost(0)
             .build();

--- a/src/main/java/com/rte_france/antares/datamanager_back/repository/ThermalGroupMappingRepository.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/repository/ThermalGroupMappingRepository.java
@@ -1,0 +1,10 @@
+package com.rte_france.antares.datamanager_back.repository;
+
+import com.rte_france.antares.datamanager_back.repository.model.ThermalGroupMappingEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ThermalGroupMappingRepository extends JpaRepository<ThermalGroupMappingEntity, Integer> {
+  Optional<ThermalGroupMappingEntity> findBySourceValueIgnoreCase(String sourceValue);
+}

--- a/src/main/java/com/rte_france/antares/datamanager_back/repository/ThermalGroupMappingRepository.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/repository/ThermalGroupMappingRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface ThermalGroupMappingRepository extends JpaRepository<ThermalGroupMappingEntity, Integer> {
-  Optional<ThermalGroupMappingEntity> findBySourceValueIgnoreCase(String sourceValue);
+  Optional<ThermalGroupMappingEntity> findByClusterIgnoreCase(String cluster);
 }

--- a/src/main/java/com/rte_france/antares/datamanager_back/repository/model/ThermalGroupMappingEntity.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/repository/model/ThermalGroupMappingEntity.java
@@ -17,9 +17,9 @@ public class ThermalGroupMappingEntity {
   @Column(name = "id", nullable = false)
   private Integer id;
 
-  @Column(name = "source_value", nullable = false, unique = true)
-  private String sourceValue;
+  @Column(name = "cluster", nullable = false, unique = true)
+  private String cluster;
 
-  @Column(name = "pemmdb_group", nullable = false)
-  private String pemmdbGroup;
+  @Column(name = "group_name", nullable = false)
+  private String groupName;
 }

--- a/src/main/java/com/rte_france/antares/datamanager_back/repository/model/ThermalGroupMappingEntity.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/repository/model/ThermalGroupMappingEntity.java
@@ -1,0 +1,25 @@
+package com.rte_france.antares.datamanager_back.repository.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "thermal_group_mapping")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+public class ThermalGroupMappingEntity {
+  @Id
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "thermal_group_mapping_seq_gen")
+  @SequenceGenerator(name = "thermal_group_mapping_seq_gen", sequenceName = "thermal_group_mapping_sequence", allocationSize = 1)
+  @Column(name = "id", nullable = false)
+  private Integer id;
+
+  @Column(name = "source_value", nullable = false, unique = true)
+  private String sourceValue;
+
+  @Column(name = "pemmdb_group", nullable = false)
+  private String pemmdbGroup;
+}

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/impl/StudyGeneratorServiceImpl.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/impl/StudyGeneratorServiceImpl.java
@@ -96,6 +96,9 @@ public class StudyGeneratorServiceImpl implements StudyGeneratorService {
             Map<String, Object> innerGeneratorMap = new TreeMap<>();
             innerGeneratorMap.put("version", "880");
             innerGeneratorMap.put("settings", "will be refactored so we'll put nothing for the moment");
+            // TODO: get input for random generation flag and number of years, maybe also move them somewhere else
+            innerGeneratorMap.put("enable_random_ts", true);
+            innerGeneratorMap.put("nb_years", 1);
             innerGeneratorMap.put("areas", areasMap);
             innerGeneratorMap.put("links", linksMap);
 

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/impl/StudyGeneratorServiceImpl.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/impl/StudyGeneratorServiceImpl.java
@@ -3,6 +3,7 @@ package com.rte_france.antares.datamanager_back.service.impl;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rte_france.antares.datamanager_back.configuration.AntaressDataManagerProperties;
 import com.rte_france.antares.datamanager_back.dto.AreaDTO;
+import com.rte_france.antares.datamanager_back.dto.ThermalClusterPropertiesDto;
 import com.rte_france.antares.datamanager_back.exception.TechnicalException;
 import com.rte_france.antares.datamanager_back.mapper.AreaMapper;
 import com.rte_france.antares.datamanager_back.repository.LoadRepository;
@@ -41,6 +42,8 @@ public class StudyGeneratorServiceImpl implements StudyGeneratorService {
     private final AntaressDataManagerProperties antaressDataManagerProperties;
 
     private final LoadFileProcessorService loadFileProcessorService;
+
+    private final ThermalClusterPropertiesBuilder thermalClusterPropertiesBuilder;
 
     private static final String PROPERTIES = "properties";
 
@@ -185,11 +188,14 @@ public class StudyGeneratorServiceImpl implements StudyGeneratorService {
 
 
         Map<String, List<String>> listArrowLoadFilesByArea = getListArrowLoadFilesByAreaFromStudy(studyEntity);
-        List<ThermalCommonParameterEntity> thermalClusterParameters = trajectory.getThermalClusterParameters();
+
+        Map<String, ThermalClusterPropertiesDto> clusterProps =
+                thermalClusterPropertiesBuilder.buildForTrajectory(trajectory);
+
         Map<String, Map<String, Object>> areasDataMap = areaDTOs.stream()
                 .collect(Collectors.toMap(
                         AreaDTO::getName,
-                        areaDTO -> areasMapGenerator(listArrowLoadFilesByArea.get(areaDTO.getName()), thermalClusterParameters)
+                        areaDTO -> areasMapGenerator(listArrowLoadFilesByArea.get(areaDTO.getName()), clusterProps)
                 ));
 
         areasMap.putAll(areasDataMap);
@@ -224,7 +230,7 @@ public class StudyGeneratorServiceImpl implements StudyGeneratorService {
      * This method should be enriched or simplified when we'll have
      * all configurations for area from input files
      */
-    private static Map<String, Object> areasMapGenerator(List<String> arrowLoadFilesByArea, List<ThermalCommonParameterEntity> thermalParameterEntities) {
+    private static Map<String, Object> areasMapGenerator(List<String> arrowLoadFilesByArea, Map<String, ThermalClusterPropertiesDto> clusterProps) {
         // This is a placeholder for the actual AreaUI and AreaProperties classes
         // Replace with actual implementations or JSON representations
         Map<String, Object> areaMap = new HashMap<>();
@@ -235,7 +241,7 @@ public class StudyGeneratorServiceImpl implements StudyGeneratorService {
         hydroMap.put(PROPERTIES, "HydroProperties as JSON");
         hydroMap.put("every matrices name inside HydroMatrixName enum", MATRIX_HASH);
 
-        Map<String, Object> thermalsMap = thermalsMapGenerator(thermalParameterEntities);
+        Map<String, Object> thermalsMap = thermalsMapGenerator(clusterProps);
 
         areaMap.put("hydro", hydroMap);
         areaMap.put("loads", arrowLoadFilesByArea != null && !arrowLoadFilesByArea.isEmpty() ? arrowLoadFilesByArea : "No LOAD files for this area");
@@ -244,30 +250,30 @@ public class StudyGeneratorServiceImpl implements StudyGeneratorService {
         return areaMap;
     }
 
-    private static Map<String, Object> thermalsMapGenerator(List<ThermalCommonParameterEntity> thermalParameterEntities) {
-        Map<String, Object> clusterMap = new HashMap<>();
-        if (thermalParameterEntities == null || thermalParameterEntities.isEmpty()) {
-            return clusterMap;
+    private static Map<String, Object> thermalsMapGenerator(
+            Map<String, ThermalClusterPropertiesDto> clusterProps
+    ) {
+        if (clusterProps == null || clusterProps.isEmpty()) {
+            return Collections.emptyMap();
         }
 
-        ObjectMapper mapper = new ObjectMapper();
-        thermalParameterEntities.forEach(thermalParameterEntity -> {
-            var propertiesMap = mapper.convertValue(thermalParameterEntity, Map.class);
-            propertiesMap.remove(thermalParameterEntity.getId());
+        Map<String, Object> clusterMap = new LinkedHashMap<>();
+
+        clusterProps.forEach((clusterName, dto) -> {
             Map<String, Object> clusterData = new HashMap<>();
-            clusterData.put(PROPERTIES, propertiesMap);
+            clusterData.put(PROPERTIES, dto);
             clusterData.put("series", MATRIX_HASH);
             clusterData.put("fuel_cost", MATRIX_HASH);
             clusterData.put("co2_cost", MATRIX_HASH);
             clusterData.put("data", MATRIX_HASH);
             clusterData.put("modulation", MATRIX_HASH);
 
-            // TODO: used ids for now but has to be replaced with cluster name
-            clusterMap.put(thermalParameterEntity.getId().toString(), clusterData);
+            clusterMap.put(clusterName, clusterData);
         });
 
-        return new HashMap<>(clusterMap);
+        return clusterMap;
     }
+
 
     private static Map<String, Object> linksMapGenerator() {
         Map<String, Object> linkMap = new HashMap<>();

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/impl/StudyGeneratorServiceImpl.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/impl/StudyGeneratorServiceImpl.java
@@ -43,7 +43,7 @@ public class StudyGeneratorServiceImpl implements StudyGeneratorService {
 
     private final LoadFileProcessorService loadFileProcessorService;
 
-    private final ThermalClusterPropertiesBuilder thermalClusterPropertiesBuilder;
+    private final ThermalPropertiesAssemblerService thermalPropertiesAssemblerService;
 
     private static final String PROPERTIES = "properties";
 
@@ -190,7 +190,7 @@ public class StudyGeneratorServiceImpl implements StudyGeneratorService {
         Map<String, List<String>> listArrowLoadFilesByArea = getListArrowLoadFilesByAreaFromStudy(studyEntity);
 
         Map<String, ThermalClusterPropertiesDto> clusterProps =
-                thermalClusterPropertiesBuilder.buildForTrajectory(trajectory);
+                thermalPropertiesAssemblerService.assembleForTrajectory(trajectory);
 
         Map<String, Map<String, Object>> areasDataMap = areaDTOs.stream()
                 .collect(Collectors.toMap(

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/impl/ThermalClusterPropertiesBuilder.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/impl/ThermalClusterPropertiesBuilder.java
@@ -1,0 +1,109 @@
+package com.rte_france.antares.datamanager_back.service.impl;
+
+import com.rte_france.antares.datamanager_back.dto.ThermalClusterPropertiesDto;
+import com.rte_france.antares.datamanager_back.repository.model.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ThermalClusterPropertiesBuilder {
+  private final ThermalGroupMappingService thermalGroupMappingService;
+
+
+  public Map<String, ThermalClusterPropertiesDto> buildForTrajectory(TrajectoryEntity trajectory) {
+    var clusterCapacityRows = Optional.ofNullable(trajectory.getThermalClusterCapacities()).orElseGet(List::of);
+    var commonParams = Optional.ofNullable(trajectory.getThermalClusterParameters()).orElseGet(List::of);
+
+    var capacityByCluster = clusterCapacityRows.stream().collect(Collectors.groupingBy(ThermalClusterCapacityEntity::getThermalClusterRef));
+    var commonParamsByCluster = commonParams.stream().collect(Collectors.groupingBy(ThermalCommonParameterEntity::getThermalClusterRef));
+
+    var out = new LinkedHashMap<String, ThermalClusterPropertiesDto>();
+    for (var entry : capacityByCluster.entrySet()) {
+      var ref = entry.getKey();
+      var thermalClusterCapacities = entry.getValue();
+      var thermalCommonParams = commonParamsByCluster.get(ref);
+
+      var dto = computeClusterProperties(thermalClusterCapacities, thermalCommonParams);
+      out.put(trajectory.getArea() + "_" + ref.getName(), dto);
+    }
+    return out;
+  }
+
+  private ThermalClusterPropertiesDto computeClusterProperties(
+      List<ThermalClusterCapacityEntity> thermalClusterCapacities,
+      List<ThermalCommonParameterEntity> thermalCommonParameters
+  ) {
+    var builder = ThermalClusterPropertiesDto.defaults().toBuilder();
+
+    buildFromClusterCapacity(thermalClusterCapacities, builder);
+    buildFromClusterParameters(thermalCommonParameters, builder);
+
+    return builder.build();
+  }
+
+  private void buildFromClusterCapacity(List<ThermalClusterCapacityEntity> thermalClusterCapacities, ThermalClusterPropertiesDto.ThermalClusterPropertiesDtoBuilder builder) {
+    // enabled
+    thermalClusterCapacities.stream()
+            .map(ThermalClusterCapacityEntity::getToUse)
+            .findFirst()
+            .ifPresent(builder::enabled);
+
+    // unit_count
+    thermalClusterCapacities.stream()
+            .filter(cap -> cap.getCategory() == ThermalCategoryEnum.NUMBER)
+            .mapToDouble(ThermalClusterCapacityEntity::getValue)
+            .max()
+            .ifPresent(unitCount -> builder.unitCount((int) unitCount));
+
+    // nominal_capacity
+    thermalClusterCapacities.stream()
+            .filter(cap -> cap.getCategory() == ThermalCategoryEnum.POWER)
+            .mapToDouble(ThermalClusterCapacityEntity::getValue)
+            .max()
+            .ifPresent(builder::nominalCapacity);
+
+    // group
+    thermalClusterCapacities.stream()
+            .map(ThermalClusterCapacityEntity::getThermalClusterRef)
+            .map(ThermalClusterRef::getName)
+            .map(thermalGroupMappingService::toGroup)
+            .findFirst()
+            .ifPresent(builder::group);
+  }
+  private void buildFromClusterParameters(List<ThermalCommonParameterEntity> thermalCommonParameters, ThermalClusterPropertiesDto.ThermalClusterPropertiesDtoBuilder builder) {
+    // min_stable_power
+    var nominalCapacity = builder.build().getNominalCapacity();
+    thermalCommonParameters.stream()
+            .mapToDouble(ThermalCommonParameterEntity::getMinStableGenerationDefault)
+            .findFirst()
+            .ifPresent(minStableGen -> builder.minStablePower(minStableGen * nominalCapacity));
+
+    // min_up_time
+    thermalCommonParameters.stream()
+            .mapToDouble(ThermalCommonParameterEntity::getMinUpTime)
+            .findFirst()
+            .ifPresent(minUpTime -> builder.minUpTime((int) minUpTime));
+
+    // min_down_time
+    thermalCommonParameters.stream()
+            .mapToDouble(ThermalCommonParameterEntity::getMinDownTime)
+            .findFirst()
+            .ifPresent(minDownTime -> builder.minDownTime((int) minDownTime));
+
+    // efficiency
+    thermalCommonParameters.stream()
+            .mapToDouble(ThermalCommonParameterEntity::getEfficiencyDefault)
+            .findFirst()
+            .ifPresent(builder::efficiency);
+
+    // variable_o_m_cost
+    thermalCommonParameters.stream()
+            .mapToDouble(ThermalCommonParameterEntity::getOmCost)
+            .findFirst()
+            .ifPresent(builder::variableOMCost);
+  }
+}

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/impl/ThermalGroupMappingService.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/impl/ThermalGroupMappingService.java
@@ -17,8 +17,8 @@ public class ThermalGroupMappingService {
   public String toGroup(String raw) {
     Objects.requireNonNull(raw);
     if (raw.isBlank()) return "OTHER1";
-    return thermalGroupMappingRepository.findBySourceValueIgnoreCase(raw.trim())
-               .map(ThermalGroupMappingEntity::getPemmdbGroup)
+    return thermalGroupMappingRepository.findByClusterIgnoreCase(raw.trim())
+               .map(ThermalGroupMappingEntity::getGroupName)
                .orElse("OTHER1"); // antares-craft default value
   }
 }

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/impl/ThermalGroupMappingService.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/impl/ThermalGroupMappingService.java
@@ -5,8 +5,11 @@ import com.rte_france.antares.datamanager_back.repository.model.ThermalGroupMapp
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Locale;
 import java.util.Objects;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -14,11 +17,11 @@ public class ThermalGroupMappingService {
   private final ThermalGroupMappingRepository thermalGroupMappingRepository;
 
   @Cacheable("thermal-group-map")
-  public String toGroup(String raw) {
+  @Transactional(readOnly = true)
+  public Optional<String> toGroup(String raw) {
     Objects.requireNonNull(raw);
-    if (raw.isBlank()) return "OTHER1";
-    return thermalGroupMappingRepository.findByClusterIgnoreCase(raw.trim())
-               .map(ThermalGroupMappingEntity::getGroupName)
-               .orElse("OTHER1"); // antares-craft default value
+    var normalized = raw.trim().toUpperCase(Locale.ROOT);
+    return thermalGroupMappingRepository.findByClusterIgnoreCase(normalized)
+               .map(ThermalGroupMappingEntity::getGroupName);
   }
 }

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/impl/ThermalGroupMappingService.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/impl/ThermalGroupMappingService.java
@@ -1,0 +1,24 @@
+package com.rte_france.antares.datamanager_back.service.impl;
+
+import com.rte_france.antares.datamanager_back.repository.ThermalGroupMappingRepository;
+import com.rte_france.antares.datamanager_back.repository.model.ThermalGroupMappingEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+public class ThermalGroupMappingService {
+  private final ThermalGroupMappingRepository thermalGroupMappingRepository;
+
+  @Cacheable("thermal-group-map")
+  public String toGroup(String raw) {
+    Objects.requireNonNull(raw);
+    if (raw.isBlank()) return "OTHER1";
+    return thermalGroupMappingRepository.findBySourceValueIgnoreCase(raw.trim())
+               .map(ThermalGroupMappingEntity::getPemmdbGroup)
+               .orElse("OTHER1"); // antares-craft default value
+  }
+}

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/impl/ThermalPropertiesAssemblerService.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/impl/ThermalPropertiesAssemblerService.java
@@ -10,11 +10,11 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-public class ThermalClusterPropertiesBuilder {
+public class ThermalPropertiesAssemblerService {
   private final ThermalGroupMappingService thermalGroupMappingService;
 
 
-  public Map<String, ThermalClusterPropertiesDto> buildForTrajectory(TrajectoryEntity trajectory) {
+  public Map<String, ThermalClusterPropertiesDto> assembleForTrajectory(TrajectoryEntity trajectory) {
     var clusterCapacityRows = Optional.ofNullable(trajectory.getThermalClusterCapacities()).orElseGet(List::of);
     var commonParams = Optional.ofNullable(trajectory.getThermalClusterParameters()).orElseGet(List::of);
 

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/impl/ThermalPropertiesAssemblerService.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/impl/ThermalPropertiesAssemblerService.java
@@ -15,6 +15,7 @@ public class ThermalPropertiesAssemblerService {
 
 
   public Map<String, ThermalClusterPropertiesDto> assembleForTrajectory(TrajectoryEntity trajectory) {
+    Objects.requireNonNull(trajectory);
     var clusterCapacityRows = Optional.ofNullable(trajectory.getThermalClusterCapacities()).orElseGet(List::of);
     var commonParams = Optional.ofNullable(trajectory.getThermalClusterParameters()).orElseGet(List::of);
 

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/impl/ThermalPropertiesAssemblerService.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/impl/ThermalPropertiesAssemblerService.java
@@ -37,7 +37,7 @@ public class ThermalPropertiesAssemblerService {
       List<ThermalClusterCapacityEntity> thermalClusterCapacities,
       List<ThermalCommonParameterEntity> thermalCommonParameters
   ) {
-    var builder = ThermalClusterPropertiesDto.defaults().toBuilder();
+    var builder = ThermalClusterPropertiesDto.builder();
 
     buildFromClusterCapacity(thermalClusterCapacities, builder);
     buildFromClusterParameters(thermalCommonParameters, builder);
@@ -72,16 +72,19 @@ public class ThermalPropertiesAssemblerService {
             .map(ThermalClusterCapacityEntity::getThermalClusterRef)
             .map(ThermalClusterRef::getName)
             .map(thermalGroupMappingService::toGroup)
+            .flatMap(Optional::stream)
             .findFirst()
             .ifPresent(builder::group);
   }
   private void buildFromClusterParameters(List<ThermalCommonParameterEntity> thermalCommonParameters, ThermalClusterPropertiesDto.ThermalClusterPropertiesDtoBuilder builder) {
     // min_stable_power
     var nominalCapacity = builder.build().getNominalCapacity();
-    thermalCommonParameters.stream()
-            .mapToDouble(ThermalCommonParameterEntity::getMinStableGenerationDefault)
-            .findFirst()
-            .ifPresent(minStableGen -> builder.minStablePower(minStableGen * nominalCapacity));
+    if (nominalCapacity != null) {
+      thermalCommonParameters.stream()
+              .mapToDouble(ThermalCommonParameterEntity::getMinStableGenerationDefault)
+              .findFirst()
+              .ifPresent(minStableGen -> builder.minStablePower(minStableGen * nominalCapacity));
+    }
 
     // min_up_time
     thermalCommonParameters.stream()

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/impl/ThermalPropertiesAssemblerService.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/impl/ThermalPropertiesAssemblerService.java
@@ -49,6 +49,7 @@ public class ThermalPropertiesAssemblerService {
     // enabled
     thermalClusterCapacities.stream()
             .map(ThermalClusterCapacityEntity::getToUse)
+            .filter(Objects::nonNull)
             .findFirst()
             .ifPresent(builder::enabled);
 

--- a/src/main/resources/db/changelog/1.1.0/V15-create_thermal_group_mapping_table.sql
+++ b/src/main/resources/db/changelog/1.1.0/V15-create_thermal_group_mapping_table.sql
@@ -2,9 +2,9 @@
 -- changeset salemsd:110V15-1
 CREATE TABLE thermal_group_mapping (
                                        id BIGINT PRIMARY KEY,
-                                       source_value  TEXT NOT NULL,
-                                       pemmdb_group  TEXT NOT NULL,
-                                       UNIQUE (source_value)
+                                       cluster  TEXT NOT NULL,
+                                       group_name  TEXT NOT NULL,
+                                       UNIQUE (cluster)
 );
 
 CREATE SEQUENCE thermal_group_mapping_sequence
@@ -14,6 +14,67 @@ CREATE SEQUENCE thermal_group_mapping_sequence
     NO MAXVALUE
     CACHE 1;
 
--- TODO: add the mappings
--- INSERT INTO thermal_group_mapping (source_value, pemmdb_group)
--- VALUES
+ALTER TABLE thermal_group_mapping
+    ALTER COLUMN id SET DEFAULT nextval('thermal_group_mapping_sequence');
+ALTER SEQUENCE thermal_group_mapping_sequence
+    OWNED BY thermal_group_mapping.id;
+
+INSERT INTO thermal_group_mapping (cluster, group_name) VALUES
+                                                                   ('Nuclear', 'Nuclear'),
+                                                                   ('Nuclear SMR', 'Nuclear'),
+
+                                                                   ('Hard coal old 1', 'Hard coal'),
+                                                                   ('Hard coal old 2', 'Hard coal'),
+                                                                   ('Hard coal new',   'Hard coal'),
+                                                                   ('Hard coal CCS',   'Hard coal'),
+
+                                                                   ('Lignite old 1', 'Lignite'),
+                                                                   ('Lignite old 2', 'Lignite'),
+                                                                   ('Lignite new',   'Lignite'),
+                                                                   ('Lignite CCS',   'Lignite'),
+
+                                                                   ('Gas conventional old 1', 'Gas'),
+                                                                   ('Gas conventional old 2', 'Gas'),
+                                                                   ('CCGT old 1',             'Gas'),
+                                                                   ('CCGT old 2',             'Gas'),
+                                                                   ('CCGT present 1',         'Gas'),
+                                                                   ('CCGT present 2',         'Gas'),
+                                                                   ('CCGT new',               'Gas'),
+                                                                   ('CCGT CCS',               'Gas'),
+                                                                   ('OCGT old',               'Gas'),
+                                                                   ('OCGT new',               'Gas'),
+
+                                                                   ('Light oil',       'Oil'),
+                                                                   ('Heavy oil old 1', 'Oil'),
+                                                                   ('Heavy oil old 2', 'Oil'),
+                                                                   ('Oil shale old',   'Oil'),
+                                                                   ('Oil shale new',   'Oil'),
+
+                                                                   ('Fuel cell', 'Fuel cell'),
+
+                                                                   ('CCGT H2',      'H2'),
+                                                                   ('OCGT H2',      'H2'),
+                                                                   ('Gas pcomp mid','H2'),
+                                                                   ('Gas pcomp peak','H2'),
+
+                                                                   ('Other non identified',      'Gas'),
+                                                                   ('Other Hard coal old 1',     'Hard coal'),
+                                                                   ('Other Hard coal old 2',     'Hard coal'),
+                                                                   ('Other Hard coal new',       'Hard coal'),
+                                                                   ('Other Hard coal CCS',       'Hard coal'),
+                                                                   ('Other Lignite old 1',       'Lignite'),
+                                                                   ('Other Lignite old 2',       'Lignite'),
+                                                                   ('Other Lignite new',         'Lignite'),
+                                                                   ('Other Lignite CCS',         'Lignite'),
+                                                                   ('Other Gas conventional old 1','Gas'),
+                                                                   ('Other Gas conventional old 2','Gas'),
+                                                                   ('Other CCGT old 1',          'Gas'),
+                                                                   ('Other CCGT old 2',          'Gas'),
+                                                                   ('Other CCGT present 1',      'Gas'),
+                                                                   ('Other CCGT present 2',      'Gas'),
+                                                                   ('Other CCGT new',            'Gas'),
+                                                                   ('Other OCGT old',            'Gas'),
+                                                                   ('Other Light oil',           'Oil'),
+                                                                   ('Other Heavy oil old 2',     'Oil'),
+                                                                   ('Other Oil shale old',       'Oil')
+

--- a/src/main/resources/db/changelog/1.1.0/V15-create_thermal_group_mapping_table.sql
+++ b/src/main/resources/db/changelog/1.1.0/V15-create_thermal_group_mapping_table.sql
@@ -16,8 +16,6 @@ CREATE SEQUENCE thermal_group_mapping_sequence
 
 ALTER TABLE thermal_group_mapping
     ALTER COLUMN id SET DEFAULT nextval('thermal_group_mapping_sequence');
-ALTER SEQUENCE thermal_group_mapping_sequence
-    OWNED BY thermal_group_mapping.id;
 
 INSERT INTO thermal_group_mapping (cluster, group_name) VALUES
                                                                    ('Nuclear', 'Nuclear'),

--- a/src/main/resources/db/changelog/1.1.0/V15-create_thermal_group_mapping_table.sql
+++ b/src/main/resources/db/changelog/1.1.0/V15-create_thermal_group_mapping_table.sql
@@ -14,13 +14,6 @@ CREATE SEQUENCE thermal_group_mapping_sequence
     NO MAXVALUE
     CACHE 1;
 
-INSERT INTO thermal_group_mapping (source_value, pemmdb_group)
-VALUES
-    ('CCGT'),
-    ( 'Coal'),
-    ( 'DSR'),
-    ( 'Nuclear'),
-    ( 'Puissance complémentaire'),
-    ( 'Storage battery'),
-    ( 'Storage EV'),
-    ( 'TBD');
+-- TODO: add the mappings
+-- INSERT INTO thermal_group_mapping (source_value, pemmdb_group)
+-- VALUES

--- a/src/main/resources/db/changelog/1.1.0/V15-create_thermal_group_mapping_table.sql
+++ b/src/main/resources/db/changelog/1.1.0/V15-create_thermal_group_mapping_table.sql
@@ -1,0 +1,26 @@
+-- liquibase formatted sql
+-- changeset salemsd:110V15-1
+CREATE TABLE thermal_group_mapping (
+                                       id BIGINT PRIMARY KEY,
+                                       source_value  TEXT NOT NULL,
+                                       pemmdb_group  TEXT NOT NULL,
+                                       UNIQUE (source_value)
+);
+
+CREATE SEQUENCE thermal_group_mapping_sequence
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+INSERT INTO thermal_group_mapping (source_value, pemmdb_group)
+VALUES
+    ('CCGT'),
+    ( 'Coal'),
+    ( 'DSR'),
+    ( 'Nuclear'),
+    ( 'Puissance complémentaire'),
+    ( 'Storage battery'),
+    ( 'Storage EV'),
+    ( 'TBD');

--- a/src/main/resources/db/changelog/1.1.0/db.changelog-1.1.0.yaml
+++ b/src/main/resources/db/changelog/1.1.0/db.changelog-1.1.0.yaml
@@ -28,3 +28,5 @@ databaseChangeLog:
       file: classpath*:db/changelog/1.1.0/V13-create-thermal-specific-parameters.sql
   - include:
       file: classpath*:db/changelog/1.1.0/V14-modify-thermal-parameter-to-common-parameters.sql
+  - include:
+      file: classpath*:db/changelog/1.1.0/V15-create_thermal_group_mapping_table.sql

--- a/src/test/java/com/rte_france/antares/datamanager_back/repository/ThermalGroupMappingRepositoryTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/repository/ThermalGroupMappingRepositoryTest.java
@@ -24,21 +24,21 @@ class ThermalGroupMappingRepositoryTest {
     @Test
     void findBySourceValueIgnoreCase_returnsHit_caseInsensitive() {
         var e = ThermalGroupMappingEntity.builder()
-                .sourceValue("conventional old 1")
-                .pemmdbGroup("Gas")
+                .cluster("conventional old 1")
+                .groupName("Gas")
                 .build();
         em.persistAndFlush(e);
 
-        Optional<ThermalGroupMappingEntity> test1 = repository.findBySourceValueIgnoreCase("conventional old 1");
-        Optional<ThermalGroupMappingEntity> test2 = repository.findBySourceValueIgnoreCase("CONVENTIONAL OLD 1");
+        Optional<ThermalGroupMappingEntity> test1 = repository.findByClusterIgnoreCase("conventional old 1");
+        Optional<ThermalGroupMappingEntity> test2 = repository.findByClusterIgnoreCase("CONVENTIONAL OLD 1");
 
         assertThat(test1).isPresent();
-        assertThat(test1.get().getPemmdbGroup()).isEqualTo("Gas");
+        assertThat(test1.get().getGroupName()).isEqualTo("Gas");
         assertThat(test2).isPresent();
     }
 
     @Test
     void findBySourceValueIgnoreCase_returnsEmpty_whenNoMatch() {
-        assertThat(repository.findBySourceValueIgnoreCase("no_match_test")).isEmpty();
+        assertThat(repository.findByClusterIgnoreCase("no_match_test")).isEmpty();
     }
 }

--- a/src/test/java/com/rte_france/antares/datamanager_back/repository/ThermalGroupMappingRepositoryTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/repository/ThermalGroupMappingRepositoryTest.java
@@ -1,0 +1,44 @@
+package com.rte_france.antares.datamanager_back.repository;
+
+import com.rte_france.antares.datamanager_back.repository.model.ThermalGroupMappingEntity;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@DataJpaTest
+class ThermalGroupMappingRepositoryTest {
+
+    @Autowired
+    private ThermalGroupMappingRepository repository;
+
+    @Autowired
+    private org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager em;
+
+    @Test
+    void findBySourceValueIgnoreCase_returnsHit_caseInsensitive() {
+        var e = ThermalGroupMappingEntity.builder()
+                .sourceValue("conventional old 1")
+                .pemmdbGroup("Gas")
+                .build();
+        em.persistAndFlush(e);
+
+        Optional<ThermalGroupMappingEntity> test1 = repository.findBySourceValueIgnoreCase("conventional old 1");
+        Optional<ThermalGroupMappingEntity> test2 = repository.findBySourceValueIgnoreCase("CONVENTIONAL OLD 1");
+
+        assertThat(test1).isPresent();
+        assertThat(test1.get().getPemmdbGroup()).isEqualTo("Gas");
+        assertThat(test2).isPresent();
+    }
+
+    @Test
+    void findBySourceValueIgnoreCase_returnsEmpty_whenNoMatch() {
+        assertThat(repository.findBySourceValueIgnoreCase("no_match_test")).isEmpty();
+    }
+}

--- a/src/test/java/com/rte_france/antares/datamanager_back/repository/ThermalGroupMappingRepositoryTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/repository/ThermalGroupMappingRepositoryTest.java
@@ -5,9 +5,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -19,26 +18,27 @@ class ThermalGroupMappingRepositoryTest {
     private ThermalGroupMappingRepository repository;
 
     @Autowired
-    private org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager em;
+    private TestEntityManager em;
 
     @Test
-    void findBySourceValueIgnoreCase_returnsHit_caseInsensitive() {
+    void findByClusterIgnoreCase_isCaseInsensitive() {
         var e = ThermalGroupMappingEntity.builder()
                 .cluster("conventional old 1")
                 .groupName("Gas")
                 .build();
         em.persistAndFlush(e);
 
-        Optional<ThermalGroupMappingEntity> test1 = repository.findByClusterIgnoreCase("conventional old 1");
-        Optional<ThermalGroupMappingEntity> test2 = repository.findByClusterIgnoreCase("CONVENTIONAL OLD 1");
+        var lower = repository.findByClusterIgnoreCase("conventional old 1");
+        var upper = repository.findByClusterIgnoreCase("CONVENTIONAL OLD 1");
 
-        assertThat(test1).isPresent();
-        assertThat(test1.get().getGroupName()).isEqualTo("Gas");
-        assertThat(test2).isPresent();
+        assertThat(lower).isPresent();
+        assertThat(lower.map(ThermalGroupMappingEntity::getGroupName)).contains("Gas");
+        assertThat(upper).isPresent();
     }
 
     @Test
-    void findBySourceValueIgnoreCase_returnsEmpty_whenNoMatch() {
-        assertThat(repository.findByClusterIgnoreCase("no_match_test")).isEmpty();
+    void findByClusterIgnoreCase_returnsEmpty_whenNoMatch() {
+        var result = repository.findByClusterIgnoreCase("does_not_exist");
+        assertThat(result).isEmpty();
     }
 }

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/StudyGeneratorServiceImplTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/StudyGeneratorServiceImplTest.java
@@ -387,7 +387,7 @@ class StudyGeneratorServiceImplTest {
 
         when(studyRepository.findById(1)).thenReturn(Optional.of(study));
 
-        var dto = ThermalClusterPropertiesDto.defaults().toBuilder()
+        var dto = ThermalClusterPropertiesDto.builder()
                 .efficiency(100.0)
                 .build();
         when(thermalPropertiesAssemblerService.assembleForTrajectory(areaTrajectory))
@@ -402,6 +402,7 @@ class StudyGeneratorServiceImplTest {
 
         Map<String, Object> jsonMap = objectMapper.readValue(captorValue, new TypeReference<>() {});
         Map<String, Object> studyMap = objectMapper.convertValue(jsonMap.get("studyTest"), new TypeReference<>() {});
+        assertThat(studyMap).containsKey("enable_random_ts");
         Map<String, Object> areasMap = objectMapper.convertValue(studyMap.get("areas"), new TypeReference<>() {});
         Map<String, Object> frArea = objectMapper.convertValue(areasMap.get("FR"), new TypeReference<>() {});
 
@@ -415,6 +416,8 @@ class StudyGeneratorServiceImplTest {
 
         Map<String, Object> properties = objectMapper.convertValue(cluster.get("properties"), new TypeReference<>() {});
         assertThat(properties).containsKey("efficiency");
+        assertThat(properties).doesNotContainKey("enabled"); // will be set to default in antares craft
+        assertThat(properties).doesNotContainKey("nominalCapacity");
     }
 
 }

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/StudyGeneratorServiceImplTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/StudyGeneratorServiceImplTest.java
@@ -415,9 +415,11 @@ class StudyGeneratorServiceImplTest {
         assertThat(cluster).containsKeys("series", "fuel_cost", "co2_cost", "data", "modulation", "properties");
 
         Map<String, Object> properties = objectMapper.convertValue(cluster.get("properties"), new TypeReference<>() {});
-        assertThat(properties).containsKey("efficiency");
-        assertThat(properties).doesNotContainKey("enabled"); // will be set to default in antares craft
-        assertThat(properties).doesNotContainKey("nominalCapacity");
+        assertAll(
+                () -> assertThat(properties).containsKey("efficiency"),
+                () -> assertThat(properties).doesNotContainKey("enabled"), // will be set to default in antares craft
+                () -> assertThat(properties).doesNotContainKey("nominalCapacity")
+        );
     }
 
 }

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/StudyGeneratorServiceImplTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/StudyGeneratorServiceImplTest.java
@@ -3,12 +3,14 @@ package com.rte_france.antares.datamanager_back.service;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rte_france.antares.datamanager_back.configuration.AntaressDataManagerProperties;
+import com.rte_france.antares.datamanager_back.dto.ThermalClusterPropertiesDto;
 import com.rte_france.antares.datamanager_back.exception.TechnicalException;
 import com.rte_france.antares.datamanager_back.repository.LoadRepository;
 import com.rte_france.antares.datamanager_back.repository.StudyRepository;
 import com.rte_france.antares.datamanager_back.repository.model.*;
 import com.rte_france.antares.datamanager_back.service.impl.NasFileService;
 import com.rte_france.antares.datamanager_back.service.impl.StudyGeneratorServiceImpl;
+import com.rte_france.antares.datamanager_back.service.impl.ThermalPropertiesAssemblerService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -58,6 +60,9 @@ class StudyGeneratorServiceImplTest {
 
     @Mock
     private LoadFileProcessorService loadFileProcessorService;
+
+    @Mock
+    private ThermalPropertiesAssemblerService thermalPropertiesAssemblerService;
 
     private final Set<TrajectoryEntity> trajectoryEntityList = new LinkedHashSet<>();
 
@@ -366,14 +371,12 @@ class StudyGeneratorServiceImplTest {
     @Test
     void buildJsonForStudyGeneration_shouldIncludeThermalsInAreas() throws Exception {
         // Given
-        var thermalParam = ThermalCommonParameterEntity.builder().id(1).build();
-
         var areaEntity = AreaEntity.builder().name("FR").build();
         var areaConfig = AreaConfigEntity.builder().area(areaEntity).build();
         var areaTrajectory = TrajectoryEntity.builder()
                 .type("AREA")
                 .areaConfigEntities(List.of(areaConfig))
-                .thermalClusterParameters(List.of(thermalParam))
+                .area("FR")
                 .build();
 
         var study = StudyEntity.builder()
@@ -382,27 +385,36 @@ class StudyGeneratorServiceImplTest {
                 .trajectories(Set.of(areaTrajectory))
                 .build();
 
-        // When
         when(studyRepository.findById(1)).thenReturn(Optional.of(study));
 
+        var dto = ThermalClusterPropertiesDto.defaults().toBuilder()
+                .efficiency(100.0)
+                .build();
+        when(thermalPropertiesAssemblerService.assembleForTrajectory(areaTrajectory))
+                .thenReturn(Map.of("FR_Gas1", dto));
+
+        // When
         studyGeneratorService.buildJsonForStudyGeneration(1);
 
+        // Then
         var captorValue = captureGeneratedJson(1);
-
         var objectMapper = new ObjectMapper();
+
         Map<String, Object> jsonMap = objectMapper.readValue(captorValue, new TypeReference<>() {});
         Map<String, Object> studyMap = objectMapper.convertValue(jsonMap.get("studyTest"), new TypeReference<>() {});
         Map<String, Object> areasMap = objectMapper.convertValue(studyMap.get("areas"), new TypeReference<>() {});
         Map<String, Object> frArea = objectMapper.convertValue(areasMap.get("FR"), new TypeReference<>() {});
 
-        // Then
-        System.out.println(areasMap);
         assertThat(frArea).containsKey("thermals");
+
         Map<String, Object> thermals = objectMapper.convertValue(frArea.get("thermals"), new TypeReference<>() {});
-        assertThat(thermals).containsKey("1");
-        Map<String, Object> cluster = objectMapper.convertValue(thermals.get("1"), new TypeReference<>() {});
-        assertThat(cluster).containsKey("series");
+        assertThat(thermals).containsKey("FR_Gas1");
+
+        Map<String, Object> cluster = objectMapper.convertValue(thermals.get("FR_Gas1"), new TypeReference<>() {});
+        assertThat(cluster).containsKeys("series", "fuel_cost", "co2_cost", "data", "modulation", "properties");
+
         Map<String, Object> properties = objectMapper.convertValue(cluster.get("properties"), new TypeReference<>() {});
-        assertThat(properties).containsKey("efficiencyRange");
+        assertThat(properties).containsKey("efficiency");
     }
+
 }

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/ThermalGroupMappingServiceTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/ThermalGroupMappingServiceTest.java
@@ -37,14 +37,9 @@ class ThermalGroupMappingServiceTest {
     }
 
     @Test
-    void toGroup_notFound_returnsDefault_OTHER1() {
+    void toGroup_notFound_returnsEmpty() {
         when(repository.findByClusterIgnoreCase("ABCDEFG")).thenReturn(Optional.empty());
-        assertThat(service.toGroup("abcdefg")).isEqualTo(Optional.empty());
-    }
-
-    @Test
-    void toGroup_blank_returnsDefault_OTHER1() {
-        assertThat(service.toGroup("   ")).isEqualTo(Optional.empty());
+        assertThat(service.toGroup("abcdefg")).isEmpty();
     }
 
     @Test

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/ThermalGroupMappingServiceTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/ThermalGroupMappingServiceTest.java
@@ -1,0 +1,56 @@
+package com.rte_france.antares.datamanager_back.service;
+
+import com.rte_france.antares.datamanager_back.repository.ThermalGroupMappingRepository;
+import com.rte_france.antares.datamanager_back.repository.model.ThermalGroupMappingEntity;
+import com.rte_france.antares.datamanager_back.service.impl.ThermalGroupMappingService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ThermalGroupMappingServiceTest {
+
+    @Mock
+    private ThermalGroupMappingRepository repository;
+
+    @InjectMocks
+    private ThermalGroupMappingService service;
+
+    @Test
+    void toGroup_found_caseInsensitive_andTrimmed() {
+        var entity = ThermalGroupMappingEntity.builder()
+                .sourceValue("conventional old 1")
+                .pemmdbGroup("Gas")
+                .build();
+
+        when(repository.findBySourceValueIgnoreCase("conventional old 1")).thenReturn(Optional.of(entity));
+        when(repository.findBySourceValueIgnoreCase("CONVENTIONAL OLD 1")).thenReturn(Optional.of(entity));
+
+        assertThat(service.toGroup(" CONVENTIONAL OLD 1 ")).isEqualTo("Gas");
+        assertThat(service.toGroup("conventional old 1")).isEqualTo("Gas");
+    }
+
+    @Test
+    void toGroup_notFound_returnsDefault_OTHER1() {
+        when(repository.findBySourceValueIgnoreCase("abcdefg")).thenReturn(Optional.empty());
+        assertThat(service.toGroup("abcdefg")).isEqualTo("OTHER1");
+    }
+
+    @Test
+    void toGroup_blank_returnsDefault_OTHER1() {
+        assertThat(service.toGroup("   ")).isEqualTo("OTHER1");
+    }
+
+    @Test
+    void toGroup_null_throwsNpe() {
+        assertThatThrownBy(() -> service.toGroup(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+}

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/ThermalGroupMappingServiceTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/ThermalGroupMappingServiceTest.java
@@ -26,12 +26,12 @@ class ThermalGroupMappingServiceTest {
     @Test
     void toGroup_found_caseInsensitive_andTrimmed() {
         var entity = ThermalGroupMappingEntity.builder()
-                .sourceValue("conventional old 1")
-                .pemmdbGroup("Gas")
+                .cluster("conventional old 1")
+                .groupName("Gas")
                 .build();
 
-        when(repository.findBySourceValueIgnoreCase("conventional old 1")).thenReturn(Optional.of(entity));
-        when(repository.findBySourceValueIgnoreCase("CONVENTIONAL OLD 1")).thenReturn(Optional.of(entity));
+        when(repository.findByClusterIgnoreCase("conventional old 1")).thenReturn(Optional.of(entity));
+        when(repository.findByClusterIgnoreCase("CONVENTIONAL OLD 1")).thenReturn(Optional.of(entity));
 
         assertThat(service.toGroup(" CONVENTIONAL OLD 1 ")).isEqualTo("Gas");
         assertThat(service.toGroup("conventional old 1")).isEqualTo("Gas");
@@ -39,7 +39,7 @@ class ThermalGroupMappingServiceTest {
 
     @Test
     void toGroup_notFound_returnsDefault_OTHER1() {
-        when(repository.findBySourceValueIgnoreCase("abcdefg")).thenReturn(Optional.empty());
+        when(repository.findByClusterIgnoreCase("abcdefg")).thenReturn(Optional.empty());
         assertThat(service.toGroup("abcdefg")).isEqualTo("OTHER1");
     }
 

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/ThermalGroupMappingServiceTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/ThermalGroupMappingServiceTest.java
@@ -30,22 +30,21 @@ class ThermalGroupMappingServiceTest {
                 .groupName("Gas")
                 .build();
 
-        when(repository.findByClusterIgnoreCase("conventional old 1")).thenReturn(Optional.of(entity));
         when(repository.findByClusterIgnoreCase("CONVENTIONAL OLD 1")).thenReturn(Optional.of(entity));
 
-        assertThat(service.toGroup(" CONVENTIONAL OLD 1 ")).isEqualTo("Gas");
-        assertThat(service.toGroup("conventional old 1")).isEqualTo("Gas");
+        assertThat(service.toGroup(" CONVENTIONAL OLD 1 ")).isEqualTo(Optional.of("Gas"));
+        assertThat(service.toGroup("conventional old 1")).isEqualTo(Optional.of("Gas"));
     }
 
     @Test
     void toGroup_notFound_returnsDefault_OTHER1() {
-        when(repository.findByClusterIgnoreCase("abcdefg")).thenReturn(Optional.empty());
-        assertThat(service.toGroup("abcdefg")).isEqualTo("OTHER1");
+        when(repository.findByClusterIgnoreCase("ABCDEFG")).thenReturn(Optional.empty());
+        assertThat(service.toGroup("abcdefg")).isEqualTo(Optional.empty());
     }
 
     @Test
     void toGroup_blank_returnsDefault_OTHER1() {
-        assertThat(service.toGroup("   ")).isEqualTo("OTHER1");
+        assertThat(service.toGroup("   ")).isEqualTo(Optional.empty());
     }
 
     @Test

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/ThermalPropertiesAssemblerServiceTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/ThermalPropertiesAssemblerServiceTest.java
@@ -13,6 +13,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -52,7 +53,7 @@ class ThermalPropertiesAssemblerServiceTest {
                 ))
                 .build();
 
-        when(groupMappingService.toGroup("Gas1")).thenReturn("GAS");
+        when(groupMappingService.toGroup("Gas1")).thenReturn(Optional.of("GAS"));
 
         // when
         var out = service.assembleForTrajectory(t);
@@ -61,7 +62,7 @@ class ThermalPropertiesAssemblerServiceTest {
         assertThat(out).hasSize(1).containsKey("FR_Gas1");
         ThermalClusterPropertiesDto dto = out.get("FR_Gas1");
 
-        assertThat(dto.isEnabled()).isTrue();
+        assertThat(dto.getEnabled()).isTrue();
         assertThat(dto.getUnitCount()).isEqualTo(3);
         assertThat(dto.getNominalCapacity()).isEqualTo(500.0);
         assertThat(dto.getGroup()).isEqualTo("GAS");
@@ -89,8 +90,8 @@ class ThermalPropertiesAssemblerServiceTest {
                 ))
                 .build();
 
-        when(groupMappingService.toGroup("Gas1")).thenReturn("GAS");
-        when(groupMappingService.toGroup("NuclearA")).thenReturn("NUCLEAR");
+        when(groupMappingService.toGroup("Gas1")).thenReturn(Optional.of("GAS"));
+        when(groupMappingService.toGroup("NuclearA")).thenReturn(Optional.of("NUCLEAR"));
 
         // when
         Map<String, ThermalClusterPropertiesDto> out = service.assembleForTrajectory(t);
@@ -102,8 +103,8 @@ class ThermalPropertiesAssemblerServiceTest {
     }
 
     @Test
-    void assembleForTrajectory_missingCategories_fallsBackToDtoDefaults() {
-        // given: no POWER category => nominalCapacity stays default (0) => minStablePower = 0
+    void assembleForTrajectory_missingCategories_fallsBackToNull() {
+        // given: no POWER category => nominalCapacity stays null => minStablePower is not computed and stays null too
         var t = TrajectoryEntity.builder()
                 .type("AREA")
                 .area("FR")
@@ -115,16 +116,16 @@ class ThermalPropertiesAssemblerServiceTest {
                 ))
                 .build();
 
-        when(groupMappingService.toGroup("Gas1")).thenReturn("GAS");
+        when(groupMappingService.toGroup("Gas1")).thenReturn(Optional.of("GAS"));
 
         // when
         var out = service.assembleForTrajectory(t);
 
         // then
         var dto = out.get("FR_Gas1");
-        assertThat(dto.getNominalCapacity()).isEqualTo(0.0);
-        assertThat(dto.getMinStablePower()).isEqualTo(0.0);
-        assertThat(dto.isEnabled()).isTrue();
+        assertThat(dto.getNominalCapacity()).isNull();
+        assertThat(dto.getMinStablePower()).isNull();
+        assertThat(dto.getEnabled()).isNull();
     }
 
     private static ThermalClusterCapacityEntity cap(ThermalClusterRef ref, ThermalCategoryEnum cat, double value, Boolean toUse) {

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/ThermalPropertiesAssemblerServiceTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/ThermalPropertiesAssemblerServiceTest.java
@@ -1,0 +1,153 @@
+package com.rte_france.antares.datamanager_back.service;
+
+import com.rte_france.antares.datamanager_back.dto.ThermalClusterPropertiesDto;
+import com.rte_france.antares.datamanager_back.repository.model.*;
+import com.rte_france.antares.datamanager_back.service.impl.ThermalGroupMappingService;
+import com.rte_france.antares.datamanager_back.service.impl.ThermalPropertiesAssemblerService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ThermalPropertiesAssemblerServiceTest {
+
+    @Mock
+    private ThermalGroupMappingService groupMappingService;
+
+    @InjectMocks
+    private ThermalPropertiesAssemblerService service;
+
+    private ThermalClusterRef gasRef;
+    private ThermalClusterRef nucRef;
+
+    @BeforeEach
+    void init() {
+        gasRef = ThermalClusterRef.builder().name("Gas1").build();
+        nucRef = ThermalClusterRef.builder().name("NuclearA").build();
+    }
+
+    @Test
+    void assembleForTrajectory_buildsOneCluster_withComputedValues() {
+        // given
+        var t = TrajectoryEntity.builder()
+                .type("AREA")
+                .area("FR")
+                .thermalClusterCapacities(List.of(
+                        cap(gasRef, ThermalCategoryEnum.NUMBER, 2.0, true),
+                        cap(gasRef, ThermalCategoryEnum.NUMBER, 3.0, null), // max= 3
+                        cap(gasRef, ThermalCategoryEnum.POWER, 450.0, null),
+                        cap(gasRef, ThermalCategoryEnum.POWER, 500.0, null) // max= 500
+                ))
+                .thermalClusterParameters(List.of(
+                        params(gasRef, 0.40, 3, 2, 41.5, 7.2) // minStablePower = 0.40 * 500
+                ))
+                .build();
+
+        when(groupMappingService.toGroup("Gas1")).thenReturn("GAS");
+
+        // when
+        var out = service.assembleForTrajectory(t);
+
+        // then
+        assertThat(out).hasSize(1).containsKey("FR_Gas1");
+        ThermalClusterPropertiesDto dto = out.get("FR_Gas1");
+
+        assertThat(dto.isEnabled()).isTrue();
+        assertThat(dto.getUnitCount()).isEqualTo(3);
+        assertThat(dto.getNominalCapacity()).isEqualTo(500.0);
+        assertThat(dto.getGroup()).isEqualTo("GAS");
+
+        assertThat(dto.getMinStablePower()).isEqualTo(200.0); // 0.40 * 500
+        assertThat(dto.getMinUpTime()).isEqualTo(3);
+        assertThat(dto.getMinDownTime()).isEqualTo(2);
+        assertThat(dto.getEfficiency()).isEqualTo(41.5);
+        assertThat(dto.getVariableOMCost()).isEqualTo(7.2);
+    }
+
+    @Test
+    void assembleForTrajectory_groupsByClusterRef_multipleClusters() {
+        // given
+        var t = TrajectoryEntity.builder()
+                .type("AREA")
+                .area("FR")
+                .thermalClusterCapacities(List.of(
+                        cap(gasRef, ThermalCategoryEnum.POWER, 100.0, true),
+                        cap(nucRef, ThermalCategoryEnum.POWER, 1200.0, true)
+                ))
+                .thermalClusterParameters(List.of(
+                        params(gasRef, 0.30, 1, 1, 55.0, 1.0),
+                        params(nucRef, 0.90, 10, 8, 33.0, 3.0)
+                ))
+                .build();
+
+        when(groupMappingService.toGroup("Gas1")).thenReturn("GAS");
+        when(groupMappingService.toGroup("NuclearA")).thenReturn("NUCLEAR");
+
+        // when
+        Map<String, ThermalClusterPropertiesDto> out = service.assembleForTrajectory(t);
+
+        // then
+        assertThat(out.keySet()).containsExactlyInAnyOrder("FR_Gas1", "FR_NuclearA");
+        assertThat(out.get("FR_Gas1").getGroup()).isEqualTo("GAS");
+        assertThat(out.get("FR_NuclearA").getGroup()).isEqualTo("NUCLEAR");
+    }
+
+    @Test
+    void assembleForTrajectory_missingCategories_fallsBackToDtoDefaults() {
+        // given: no POWER category => nominalCapacity stays default (0) => minStablePower = 0
+        var t = TrajectoryEntity.builder()
+                .type("AREA")
+                .area("FR")
+                .thermalClusterCapacities(List.of(
+                        cap(gasRef, ThermalCategoryEnum.NUMBER, 1.0, null) // only NUMBER provided
+                ))
+                .thermalClusterParameters(List.of(
+                        params(gasRef, 0.50, 2, 2, 60.0, 5.0)
+                ))
+                .build();
+
+        when(groupMappingService.toGroup("Gas1")).thenReturn("GAS");
+
+        // when
+        var out = service.assembleForTrajectory(t);
+
+        // then
+        var dto = out.get("FR_Gas1");
+        assertThat(dto.getNominalCapacity()).isEqualTo(0.0);
+        assertThat(dto.getMinStablePower()).isEqualTo(0.0);
+        assertThat(dto.isEnabled()).isTrue();
+    }
+
+    private static ThermalClusterCapacityEntity cap(ThermalClusterRef ref, ThermalCategoryEnum cat, double value, Boolean toUse) {
+        return ThermalClusterCapacityEntity.builder()
+                .thermalClusterRef(ref)
+                .category(cat)
+                .value(value)
+                .toUse(toUse)
+                .build();
+    }
+
+    private static ThermalCommonParameterEntity params(ThermalClusterRef ref,
+                                                       double minStableGenDefault,
+                                                       int minUp, int minDown,
+                                                       double effDefault, double omCost) {
+        return ThermalCommonParameterEntity.builder()
+                .thermalClusterRef(ref)
+                .minStableGenerationDefault(minStableGenDefault)
+                .minUpTime((double) minUp)
+                .minDownTime((double) minDown)
+                .efficiencyDefault(effDefault)
+                .omCost(omCost)
+                .build();
+    }
+}

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/ThermalPropertiesAssemblerServiceTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/ThermalPropertiesAssemblerServiceTest.java
@@ -13,7 +13,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;


### PR DESCRIPTION
**A voir:** garder la logique dans la classe ThermalPropertiesAssemblerService ou tout mettre dans StudyGeneratorService

Le DTO est toujours créée avec les valeurs par défaut antares craft. Elles sont ensuite modifiées selon les fichiers capacity et common. Les valeurs qu'on n'a pas pu trouvé vont rester default

- Les propriétés restantes à traiter avec SpecificParameters:
	- spinning
	- market_bid_cost
- ThermalCost:
	- marginal_cost qui dépend de vom, co2_emission_factor, co2_price, fuel_price
	- co2: economic_params