### PR TITLE
removed `isCivilYear` parameter from `buildThermalCommonParameterValu…

### DIFF
--- a/src/main/java/com/rte_france/antares/datamanager_back/service/ThermalFileProcessorService.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/ThermalFileProcessorService.java
@@ -20,6 +20,6 @@ public interface ThermalFileProcessorService {
 
      ThermalClusterCapacityDto buildThermalClusterCapacityValuesList(Path path, String horizon, boolean isCivilYear, String area, String technology, Integer studyId) throws IOException;
 
-     List<ThermalCommonParameterEntity> buildThermalCommonParameterValuesList(Path path, String horizon, boolean isCivilYear) throws IOException;
+     List<ThermalCommonParameterEntity> buildThermalCommonParameterValuesList(Path path, String horizon) throws IOException;
 
     }

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/impl/ThermalFileProcessorServiceImpl.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/impl/ThermalFileProcessorServiceImpl.java
@@ -50,7 +50,7 @@ public class ThermalFileProcessorServiceImpl implements ThermalFileProcessorServ
 
 
     @Override
-    public List<ThermalCommonParameterEntity> buildThermalCommonParameterValuesList(Path path, String horizon, boolean isCivilYear) throws IOException {
+    public List<ThermalCommonParameterEntity> buildThermalCommonParameterValuesList(Path path, String horizon) throws IOException {
         List<ThermalCommonParameterEntity> thermalParameters = new ArrayList<>();
         try (InputStream inputStream = Files.newInputStream(path);
              Workbook workbook = WorkbookFactory.create(inputStream)) {

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/impl/TrajectoryServiceImpl.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/impl/TrajectoryServiceImpl.java
@@ -306,7 +306,7 @@ public class TrajectoryServiceImpl implements TrajectoryService {
     @Override
     public TrajectoryEntity processThermalCommonParameterTrajectory(String trajectoryToUse, String horizon, Integer studyId) throws IOException {
         Path trajectoryFilePath = getTrajectoryFilePath(TrajectoryType.THERMAL_TECHNICAL_COMMON_PARAMETER, trajectoryToUse,"");
-        var params = thermalFileProcessorService.buildThermalCommonParameterValuesList(trajectoryFilePath, horizon, true);
+        var params = thermalFileProcessorService.buildThermalCommonParameterValuesList(trajectoryFilePath, horizon);
         if (CollectionUtils.isEmpty(params)) {
             throw BusinessException.builder()
                     .errorMessageArguments(List.of(trajectoryToUse, horizon))

--- a/src/main/java/com/rte_france/antares/datamanager_back/util/Utils.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/util/Utils.java
@@ -47,6 +47,7 @@ public class Utils {
     private static final String AREAS_PREFIX = "areas_";
     private static final String LINKS_PREFIX = "links_";
     private static final String THERMAL_PREFIX = "thermal_";
+    private static final String THERMAL_COMMON_PREFIX = "common_param";
 
     public static final String OTHERS_AREA = "OTHERS";
 
@@ -175,7 +176,9 @@ public class Utils {
         } else if (Objects.equals(trajectoryType, TrajectoryType.LINK.toString())) {
             prefix = LINKS_PREFIX;
         } else if (Objects.equals(trajectoryType, TrajectoryType.THERMAL_CAPACITY.toString())) {
-            prefix = THERMAL_PREFIX;
+            prefix = THERMAL_PREFIX;}
+        else if (Objects.equals(trajectoryType, TrajectoryType.THERMAL_TECHNICAL_COMMON_PARAMETER.toString())) {
+            prefix = THERMAL_COMMON_PREFIX;
         } else {
             prefix = "";
         }
@@ -205,26 +208,26 @@ public class Utils {
     }
 
     /**
-     * Searches for and returns the first sheet in the given workbook whose name
-     * is a valid year (numeric).
+     * Finds a sheet in the provided workbook that matches the given horizon name.
+     * The search attempts an exact match with the horizon name if it is not null or blank.
      *
-     * @param workbook the workbook to search through
-     * @param horizon a string parameter not currently used in the method logic
-     * @return the first sheet with a numerically valid year name, or null if no such sheet is found
+     * @param workbook the workbook to search in; must not be null
+     * @param horizon the name of the horizon to locate; can be null or blank
+     * @return the sheet matching the horizon name, or null if no match is found
      */
     public static Sheet findHorizonSheet(Workbook workbook, String horizon) {
-        for (var i = 0; i < workbook.getNumberOfSheets(); i++) {
-            Sheet currentSheet = workbook.getSheetAt(i);
-            if (isSheetNameYearNumber(currentSheet)) {
-                return currentSheet;
-            }
+        if (workbook == null) return null;
+
+        if (horizon != null && !horizon.isBlank()) {
+            return workbook.getSheet(horizon);
+
         }
         return null;
     }
 
 
-    public Object getCellValue(Row row, int cellIndex) {
-        Cell cell = row.getCell(cellIndex);
+    public static Object getCellValue(Row row, int cellIndex) {
+        Cell cell = row.getCell(cellIndex, Row.MissingCellPolicy.RETURN_BLANK_AS_NULL);
         if (cell == null) {
             return null;
         }

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/ThermalFileProcessorServiceImplTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/ThermalFileProcessorServiceImplTest.java
@@ -640,7 +640,7 @@ class ThermalFileProcessorServiceImplTest {
         when(thermalTechnologyRepository.findThermalTechnologyByName("CCGT")).thenReturn(Optional.of(tech));
         when(thermalClusterRefRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
-        var list = thermalFileProcessorService.buildThermalCommonParameterValuesList(file, HORIZON_SHEET, true);
+        var list = thermalFileProcessorService.buildThermalCommonParameterValuesList(file, HORIZON_SHEET);
         assertEquals(1, list.size());
         ThermalCommonParameterEntity e = list.get(0);
         assertNotNull(e.getThermalClusterRef());
@@ -654,7 +654,7 @@ class ThermalFileProcessorServiceImplTest {
     void buildThermalCommonParameterValuesList_shouldThrowTechnicalExceptionWhenHorizonSheetMissing(@TempDir Path tempDir) throws Exception {
         Path file = mockExcelFile(tempDir, THERMAL_PARAMETERS_FILE_NAME, () -> generateCommonParametersExcelFile("OTHER_SHEET"));
         TechnicalException ex = assertThrows(TechnicalException.class, () ->
-                thermalFileProcessorService.buildThermalCommonParameterValuesList(file, HORIZON_SHEET, true)
+                thermalFileProcessorService.buildThermalCommonParameterValuesList(file, HORIZON_SHEET)
         );
         assertTrue(ex.getMessage().contains("missing suitable sheet"));
     }

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/TrajectoryServiceImplTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/TrajectoryServiceImplTest.java
@@ -1002,7 +1002,7 @@ class TrajectoryServiceImplTest {
         Integer studyId = 1;
         List<ThermalCommonParameterEntity> params = List.of(ThermalCommonParameterEntity.builder().id(1).build());
 
-        when(thermalFileProcessorService.buildThermalCommonParameterValuesList(any(Path.class), eq(horizon), anyBoolean())).thenReturn(params);
+        when(thermalFileProcessorService.buildThermalCommonParameterValuesList(any(Path.class), eq(horizon))).thenReturn(params);
         when(thermalFileProcessorService.processThermalCommonParameterFile(any(Path.class), eq(horizon), eq(params), eq(TrajectoryType.THERMAL_TECHNICAL_COMMON_PARAMETER)))
                 .thenReturn(new TrajectoryEntity());
 
@@ -1020,7 +1020,7 @@ class TrajectoryServiceImplTest {
         Integer studyId = 1;
         Path mockPath = mock(Path.class);
 
-        when(thermalFileProcessorService.buildThermalCommonParameterValuesList(mockPath, horizon, true)).thenReturn(Collections.emptyList());
+        when(thermalFileProcessorService.buildThermalCommonParameterValuesList(mockPath, horizon)).thenReturn(Collections.emptyList());
 
         BusinessException exception = assertThrows(BusinessException.class, () ->
                 trajectoryService.processThermalCommonParameterTrajectory(trajectoryToUse, horizon, studyId)


### PR DESCRIPTION
…esList` across thermal service implementations and test cases, updated related utility methods for simplification and clarity