### PR TITLE
Fix: ANT-4487: éviter les NPE lors de l'utilisation de mapToDouble sur valeur est null

### DIFF
--- a/src/main/java/com/rte_france/antares/datamanager_back/service/thermal/impl/ThermalPropertiesAssemblerService.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/thermal/impl/ThermalPropertiesAssemblerService.java
@@ -10,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.rte_france.antares.datamanager_back.dto.TrajectoryType.*;
@@ -148,6 +149,21 @@ public class ThermalPropertiesAssemblerService {
                 ));
     }
 
+    /**
+     * Renvoie le premier Double non-null de la collection, converti en double.
+     * NPE-safe (collection null, éléments null, valeur mappée null).
+     */
+    private static <T> OptionalDouble firstNonNullDouble(Collection<T> source, Function<T, Double> mapper) {
+        if (source == null || source.isEmpty()) return OptionalDouble.empty();
+
+        return source.stream()
+                .filter(Objects::nonNull)
+                .map(mapper)                  // Stream<Double>
+                .filter(Objects::nonNull)
+                .mapToDouble(Double::doubleValue)
+                .findFirst();
+    }
+
     private ThermalClusterGenerationDto computeClusterProperties(
             List<ThermalClusterCapacityEntity> thermalClusterCapacities,
             List<ThermalCommonParameterEntity> thermalCommonParameters,
@@ -199,14 +215,22 @@ public class ThermalPropertiesAssemblerService {
 
         // max POWER capacity
         OptionalDouble maxPowerOpt = thermalClusterCapacities.stream()
+                .filter(Objects::nonNull)
                 .filter(cap -> cap.getCategory() == ThermalCategoryEnum.POWER)
-                .mapToDouble(ThermalClusterCapacityEntity::getValue)
+                .map(ThermalClusterCapacityEntity::getValue)
+                .filter(Objects::nonNull)
+                .mapToDouble(Double::doubleValue)
                 .max();
-        //max unit count
+
+        // max unit count
         OptionalDouble unitCountOpt = thermalClusterCapacities.stream()
+                .filter(Objects::nonNull)
                 .filter(cap -> cap.getCategory() == ThermalCategoryEnum.NUMBER)
-                .mapToDouble(ThermalClusterCapacityEntity::getValue)
+                .map(ThermalClusterCapacityEntity::getValue) 
+                .filter(Objects::nonNull)
+                .mapToDouble(Double::doubleValue)
                 .max();
+                
         // nominal capacity (max POWER / unitCount) ---
         if (maxPowerOpt.isPresent()) {
             double maxPower = maxPowerOpt.getAsDouble();
@@ -245,62 +269,42 @@ public class ThermalPropertiesAssemblerService {
         // min_stable_power
         var nominalCapacity = builder.build().getNominalCapacity();
         if (nominalCapacity != null) {
-            thermalCommonParameters.stream()
-                    .mapToDouble(ThermalCommonParameterEntity::getMinStableGenerationDefault)
-                    .findFirst()
+            firstNonNullDouble(thermalCommonParameters, ThermalCommonParameterEntity::getMinStableGenerationDefault)
                     .ifPresent(minStableGen -> builder.minStablePower(round(minStableGen * nominalCapacity)));
         }
 
         // min_up_time
-        thermalCommonParameters.stream()
-                .mapToDouble(ThermalCommonParameterEntity::getMinUpTime)
-                .findFirst()
+        firstNonNullDouble(thermalCommonParameters, ThermalCommonParameterEntity::getMinUpTime)
                 .ifPresent(minUpTime -> builder.minUpTime((int) minUpTime));
 
         // min_down_time
-        thermalCommonParameters.stream()
-                .mapToDouble(ThermalCommonParameterEntity::getMinDownTime)
-                .findFirst()
+        firstNonNullDouble(thermalCommonParameters, ThermalCommonParameterEntity::getMinDownTime)
                 .ifPresent(minDownTime -> builder.minDownTime((int) minDownTime));
 
-        // efficiency
-        thermalCommonParameters.stream()
-                .mapToDouble(thermalCommonParam -> thermalCommonParam.getEfficiencyDefault() * 100) // convert to percentage
-                .findFirst()
-                .ifPresent(efficiency -> builder.efficiency(round(efficiency)));
+        // efficiency (convert to percentage)
+        firstNonNullDouble(thermalCommonParameters, p ->
+                p.getEfficiencyDefault() == null ? null : p.getEfficiencyDefault() * 100
+        ).ifPresent(efficiency -> builder.efficiency(round(efficiency)));
 
         // variable_o_m_cost
-        thermalCommonParameters.stream()
-                .mapToDouble(ThermalCommonParameterEntity::getOmCost)
-                .findFirst()
+        firstNonNullDouble(thermalCommonParameters, ThermalCommonParameterEntity::getOmCost)
                 .ifPresent(omCost -> builder.variableOMCost(round(omCost)));
 
-
-
-        //FO rate
-        thermalCommonParameters.stream()
-                .mapToDouble(ThermalCommonParameterEntity::getFoRateDefault)
-                .findFirst()
+        // FO rate
+        firstNonNullDouble(thermalCommonParameters, ThermalCommonParameterEntity::getFoRateDefault)
                 .ifPresent(foRate -> builder.foCommonRate(round(foRate)));
 
-        //FO duration
-        thermalCommonParameters.stream()
-                .mapToDouble(ThermalCommonParameterEntity::getFoDurationDefault)
-                .findFirst()
+        // FO duration
+        firstNonNullDouble(thermalCommonParameters, ThermalCommonParameterEntity::getFoDurationDefault)
                 .ifPresent(foDuration -> builder.foCommonDuration(round(foDuration)));
 
-        //PO rate
-        thermalCommonParameters.stream()
-                .mapToDouble(ThermalCommonParameterEntity::getPoWinterDefault)
-                .findFirst()
+        // PO rate
+        firstNonNullDouble(thermalCommonParameters, ThermalCommonParameterEntity::getPoWinterDefault)
                 .ifPresent(poRate -> builder.poCommonRate(round(poRate)));
-        //PO duration
-        thermalCommonParameters.stream()
-                .mapToDouble(ThermalCommonParameterEntity::getPoDurationDefault)
-                .findFirst()
+
+        // PO duration
+        firstNonNullDouble(thermalCommonParameters, ThermalCommonParameterEntity::getPoDurationDefault)
                 .ifPresent(poDuration -> builder.poCommonDuration(round(poDuration)));
-
-
     }
 
     private void buildFromSpecificParameters(List<ThermalSpecificParametersEntity> thermalSpecificParameters, ThermalClusterGenerationDto.ThermalClusterGenerationDtoBuilder builder) {

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/ThermalPropertiesAssemblerServiceTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/ThermalPropertiesAssemblerServiceTest.java
@@ -1016,4 +1016,64 @@ class ThermalPropertiesAssemblerServiceTest {
         // market_bid_cost = marginal_cost (100.0) - om_cost (0.0) = 100.0
         assertThat(dto.getMarketBidCost()).isEqualTo(100.0);
     }
+
+    @Test
+    void assembleForTrajectories_doesNotThrow_andKeepsCommonFieldsNull_whenCommonPropertiesAreNull() {
+        // given
+        // Capacity trajectory: ensures nominalCapacity is computed (POWER max / NUMBER max)
+        var capTraj = TrajectoryEntity.builder()
+                .type(TrajectoryType.THERMAL_CAPACITY.name())
+                .thermalClusterCapacities(List.of(
+                        cap(gasRef, ThermalCategoryEnum.NUMBER, 2.0, true).toBuilder().area("FR").build(),
+                        cap(gasRef, ThermalCategoryEnum.POWER, 200.0, true).toBuilder().area("FR").build()
+                ))
+                .build();
+
+        // Common parameters: all fields used by buildFromCommonParameters are null
+        var commonAllNull = ThermalCommonParameterEntity.builder()
+                .thermalClusterRef(gasRef)
+                .minStableGenerationDefault(null)
+                .minUpTime(null)
+                .minDownTime(null)
+                .efficiencyDefault(null)
+                .omCost(null)
+                .foRateDefault(null)
+                .foDurationDefault(null)
+                .poWinterDefault(null)
+                .poDurationDefault(null)
+                .build();
+
+        var commonTraj = TrajectoryEntity.builder()
+                .type(TrajectoryType.THERMAL_TECHNICAL_COMMON_PARAMETER.name())
+                .thermalCommonParameters(List.of(commonAllNull))
+                .build();
+
+        when(groupMappingService.toGroup("Gas1")).thenReturn(Optional.of("GAS"));
+
+        // when
+        var out = service.assembleForTrajectories(
+                StudyEntity.builder().trajectories(Set.of(capTraj, commonTraj)).build()
+        );
+
+        // then
+        var key = new ThermalPropertiesAssemblerService.AreaClusterRefKey("FR", gasRef);
+        assertThat(out).containsKey(key);
+
+        var dto = out.get(key);
+
+        // capacity-derived values exist
+        assertThat(dto.getNominalCapacity()).isNotNull();
+        assertThat(dto.getEnabled()).isTrue();
+
+        // common-parameter-derived values remain null (because inputs were null and should not NPE)
+        assertThat(dto.getMinStablePower()).isNull();
+        assertThat(dto.getMinUpTime()).isNull();
+        assertThat(dto.getMinDownTime()).isNull();
+        assertThat(dto.getEfficiency()).isNull();
+        assertThat(dto.getVariableOMCost()).isNull();
+        assertThat(dto.getFoCommonRate()).isNull();
+        assertThat(dto.getFoCommonDuration()).isNull();
+        assertThat(dto.getPoCommonRate()).isNull();
+        assertThat(dto.getPoCommonDuration()).isNull();
+    }
 }


### PR DESCRIPTION
https://gopro-tickets.rte-france.com/browse/ANT-4487