### PR TITLE
Fix: ANT-4707 - values in required columns

### DIFF
--- a/src/main/java/com/rte_france/antares/datamanager_back/controller/ResController.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/controller/ResController.java
@@ -41,7 +41,7 @@ public class ResController {
     @PostMapping("/load-factor-res")
     public ResponseEntity<TrajectoryDTO> uploadLoadFactorResTrajectory(
             @RequestParam("area") String area,
-            @RequestParam("trajectoryToUse") @Size(max = 40, message = "Trajectory name cannot exceed 40 characters") String trajectoryToUse,
+            @RequestParam("trajectoryToUse") @Size(max = 40, message = "Trajectory name cannot exceed 40 characters") @Pattern(regexp = "^[a-zA-Z0-9_-]+$") String trajectoryToUse,
             @RequestParam("horizon") @Pattern(regexp = "^\\d{4}-\\d{4}$") String horizon,
             @RequestParam("studyId") Integer studyId,
             @RequestParam(value = "technology", required = false) String technology) throws IOException {

--- a/src/main/java/com/rte_france/antares/datamanager_back/controller/ResController.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/controller/ResController.java
@@ -41,7 +41,7 @@ public class ResController {
     @PostMapping("/load-factor-res")
     public ResponseEntity<TrajectoryDTO> uploadLoadFactorResTrajectory(
             @RequestParam("area") String area,
-            @RequestParam("trajectoryToUse") @Size(max = 40, message = "Trajectory name cannot exceed 40 characters") @Pattern(regexp = "^[a-zA-Z0-9_-]+$") String trajectoryToUse,
+            @RequestParam("trajectoryToUse") @Size(max = 40, message = "Trajectory name cannot exceed 40 characters") String trajectoryToUse,
             @RequestParam("horizon") @Pattern(regexp = "^\\d{4}-\\d{4}$") String horizon,
             @RequestParam("studyId") Integer studyId,
             @RequestParam(value = "technology", required = false) String technology) throws IOException {
@@ -54,7 +54,7 @@ public class ResController {
     public ResponseEntity<TrajectoryDTO> uploadInstalledResTrajectory(
             @RequestParam("area") String area,
             @RequestParam(value = "technology", required = false) String technology,
-            @RequestParam("trajectoryToUse") @Size(max = 40, message = "Trajectory name cannot exceed 40 characters") @Pattern(regexp = "^[a-zA-Z0-9_-]+$") String trajectoryToUse,
+            @RequestParam("trajectoryToUse") @Size(max = 40, message = "Trajectory name cannot exceed 40 characters") String trajectoryToUse,
             @RequestParam("horizon") @Pattern(regexp = "^\\d{4}-\\d{4}$") String horizon,
             @RequestParam("studyId") Integer studyId,
             @RequestParam("isCivilYear") boolean isCivilYear) throws IOException {
@@ -69,7 +69,7 @@ public class ResController {
     public ResponseEntity<TrajectoryDTO> uploadTechnologyDistributionResTrajectory(
             @RequestParam("area") String area,
             @RequestParam(value = "technology", required = false) String technology,
-            @RequestParam("trajectoryToUse") @Size(max = 40, message = "Trajectory name cannot exceed 40 characters") @Pattern(regexp = "^[a-zA-Z0-9_-]+$") String trajectoryToUse,
+            @RequestParam("trajectoryToUse") @Size(max = 40, message = "Trajectory name cannot exceed 40 characters") String trajectoryToUse,
             @RequestParam("horizon") @Pattern(regexp = "^\\d{4}-\\d{4}$") String horizon,
             @RequestParam("studyId") Integer studyId,
             @RequestParam("isCivilYear") boolean isCivilYear) throws IOException {
@@ -84,7 +84,7 @@ public class ResController {
     public ResponseEntity<TrajectoryDTO> uploadZonalDistributionResTrajectory(
             @RequestParam("area") String area,
             @RequestParam(value = "technology", required = false) String technology,
-            @RequestParam("trajectoryToUse") @Size(max = 40, message = "Trajectory name cannot exceed 40 characters") @Pattern(regexp = "^[a-zA-Z0-9_-]+$") String trajectoryToUse,
+            @RequestParam("trajectoryToUse") @Size(max = 40, message = "Trajectory name cannot exceed 40 characters") String trajectoryToUse,
             @RequestParam("horizon") @Pattern(regexp = "^\\d{4}-\\d{4}$") String horizon,
             @RequestParam("studyId") Integer studyId,
             @RequestParam("isCivilYear") boolean isCivilYear) throws IOException {

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/res/impl/ResFileProcessorServiceImpl.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/res/impl/ResFileProcessorServiceImpl.java
@@ -55,7 +55,7 @@ public class ResFileProcessorServiceImpl implements ResFileProcessorService {
     protected static final String[] REQUIRED_CLUSTER_COLUMNS = {
             "ToUse", AREA_COLUMN, GROUP_COLUMN, CLUSTER_COLUMN, "Category"};
     protected static final String[] REQUIRED_OFFSHORE_CLUSTER_COLUMNS = {
-            "ToUse", AREA_COLUMN, GROUP_COLUMN, CLUSTER_COLUMN, PECD_ZONE_COLUMN};
+            "ToUse", AREA_COLUMN, PECD_ZONE_COLUMN, GROUP_COLUMN, CLUSTER_COLUMN};
     protected static final String[] REQUIRED_TECHNOLOGY_DISTRIBUTION_COLUMNS = {
             GROUP_COLUMN, CLUSTER_COLUMN, PECD_ZONE_COLUMN, "Techno_PECD"};
     protected static final String[] REQUIRED_ZONAL_DISTRIBUTION_COLUMNS = {
@@ -558,7 +558,7 @@ public class ResFileProcessorServiceImpl implements ResFileProcessorService {
 
         if (!shouldProcessArea(context, result, area, group)) return;
 
-        validateEmptyRequiredColumns(context, requiredColumns, toUse, area, col2, col3, col4);
+        validateEmptyRequiredColumns(context, requiredColumns, toUse, area, col2, group, cluster);
 
         String combo = LITERAL_STRING.formatted(area, group, cluster);
 


### PR DESCRIPTION
https://gopro-tickets.rte-france.com/browse/ANT-4707 :
offshore de FR => mauvais nom de colonnes dans le message d'erreur

https://gopro-tickets.rte-france.com/browse/ANT-4839 : 
regex appliquée sur le nom du fichier de trajectoire enlevé