### PR TITLE
fix: hydro/psp anomalies

### DIFF
--- a/src/main/java/com/rte_france/antares/datamanager_back/dto/HydroPropertiesGenerationDTO.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/dto/HydroPropertiesGenerationDTO.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
+
 @Data
 @Builder(toBuilder = true)
 @AllArgsConstructor
@@ -16,13 +18,13 @@ public class HydroPropertiesGenerationDTO {
     private Boolean followLoadModulation;
 
     @JsonProperty("inter_daily_breakdown")
-    private Integer interDailyBreakdown;
+    private BigDecimal interDailyBreakdown;
 
     @JsonProperty("inter_daily_modulation")
-    private Integer interDailyModulation;
+    private BigDecimal interDailyModulation;
 
     @JsonProperty("inter_monthly_breakdown")
-    private Integer interMonthlyBreakdown;
+    private BigDecimal interMonthlyBreakdown;
 
     @JsonProperty("reservoir")
     private Boolean reservoirManagement;
@@ -31,10 +33,10 @@ public class HydroPropertiesGenerationDTO {
     private Integer reservoirCapacity;
 
     @JsonProperty("pumping_efficiency")
-    private Integer pumpingEfficiency;
+    private BigDecimal pumpingEfficiency;
 
     @JsonProperty("initialize_reservoir_date")
-    private Integer initializeReservoirDate;
+    private BigDecimal initializeReservoirDate;
 
     @JsonProperty("use_water")
     private Boolean useWater;

--- a/src/main/java/com/rte_france/antares/datamanager_back/dto/HydroPropertiesGenerationDTO.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/dto/HydroPropertiesGenerationDTO.java
@@ -30,7 +30,7 @@ public class HydroPropertiesGenerationDTO {
     private Boolean reservoirManagement;
 
     @JsonProperty("reservoir_capacity")
-    private Integer reservoirCapacity;
+    private BigDecimal reservoirCapacity;
 
     @JsonProperty("pumping_efficiency")
     private BigDecimal pumpingEfficiency;

--- a/src/main/java/com/rte_france/antares/datamanager_back/dto/HydroPropertiesGenerationDTO.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/dto/HydroPropertiesGenerationDTO.java
@@ -36,7 +36,7 @@ public class HydroPropertiesGenerationDTO {
     private BigDecimal pumpingEfficiency;
 
     @JsonProperty("initialize_reservoir_date")
-    private BigDecimal initializeReservoirDate;
+    private Integer initializeReservoirDate;
 
     @JsonProperty("use_water")
     private Boolean useWater;

--- a/src/main/java/com/rte_france/antares/datamanager_back/mapper/HydroMapper.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/mapper/HydroMapper.java
@@ -18,7 +18,7 @@ public class HydroMapper {
                     .interDailyModulation(entity.getInterDailyModulation())
                     .interMonthlyBreakdown(entity.getInterMonthlyBreakdown())
                     .reservoirManagement(entity.getReservoir())
-                    .reservoirCapacity(entity.getReservoirCapacity() != null ? entity.getReservoirCapacity().intValue() : null)
+                    .reservoirCapacity(entity.getReservoirCapacity())
                     .pumpingEfficiency(entity.getPumpingEfficiency())
                     .initializeReservoirDate(entity.getInitializeReservoirDate())
                     .useWater(entity.getUseWater())

--- a/src/main/java/com/rte_france/antares/datamanager_back/repository/model/HydroParametersEntity.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/repository/model/HydroParametersEntity.java
@@ -28,19 +28,19 @@ public class HydroParametersEntity {
     private String node;
 
     @Column(name = "inter_daily_breakdown")
-    private Integer interDailyBreakdown;
+    private BigDecimal interDailyBreakdown;
 
     @Column(name = "inter_daily_modulation")
-    private Integer interDailyModulation;
+    private BigDecimal interDailyModulation;
 
     @Column(name = "inter_monthly_breakdown")
-    private Integer interMonthlyBreakdown;
+    private BigDecimal interMonthlyBreakdown;
 
     @Column(name = "initialize_reservoir_date")
-    private Integer initializeReservoirDate;
+    private BigDecimal initializeReservoirDate;
 
     @Column(name = "pumping_efficiency")
-    private Integer pumpingEfficiency;
+    private BigDecimal pumpingEfficiency;
 
     @Column(name = "reservoir")
     private Boolean reservoir;

--- a/src/main/java/com/rte_france/antares/datamanager_back/repository/model/HydroParametersEntity.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/repository/model/HydroParametersEntity.java
@@ -37,7 +37,7 @@ public class HydroParametersEntity {
     private BigDecimal interMonthlyBreakdown;
 
     @Column(name = "initialize_reservoir_date")
-    private BigDecimal initializeReservoirDate;
+    private Integer initializeReservoirDate;
 
     @Column(name = "pumping_efficiency")
     private BigDecimal pumpingEfficiency;

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/hydro/impl/HydroCoherenceCheckServiceImpl.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/hydro/impl/HydroCoherenceCheckServiceImpl.java
@@ -35,10 +35,10 @@ public class HydroCoherenceCheckServiceImpl implements HydroCoherenceCheckServic
         TrajectoryEntity tpTrajectory = trajectoryRepository.findLatestByStudyIdAndAreaAndType(studyId, areaParam, targetTpType);
             if (tpTrajectory != null) {
                 List<String> areasInHydroAllocationEntities = getAreasInHydroAllocationAreas(tpTrajectory.getId());
-                boolean isHydroAllocationTrajectoryHasAreas = areasInHydroAllocationEntities.containsAll(areasInHydroSeriesFiles);
+                boolean isHydroAllocationTrajectoryHasAreas = containsAllIgnoreCase(areasInHydroAllocationEntities, areasInHydroSeriesFiles);
                 if (isHydroAllocationTrajectoryHasAreas) {
                     List<String> areasInHydroParametersEntities = getAreasInHydroParametersAreas(tpTrajectory.getId());
-                    boolean isHydroParametersTrajectoryHasAreas = areasInHydroParametersEntities.containsAll(areasInHydroSeriesFiles);
+                    boolean isHydroParametersTrajectoryHasAreas = containsAllIgnoreCase(areasInHydroParametersEntities, areasInHydroSeriesFiles);
                     if (!isHydroParametersTrajectoryHasAreas) {
                         String label = HydroTypeHelper.getFileLabel("hydroParameters", isPsp);
                         throw BusinessException.builder()
@@ -63,7 +63,7 @@ public class HydroCoherenceCheckServiceImpl implements HydroCoherenceCheckServic
         TrajectoryEntity seriesTrajectory = trajectoryRepository.findLatestByStudyIdAndAreaAndType(studyId, areaParam, targetSeriesType);
         if (seriesTrajectory != null) {
             List<String> areasModInHydroSeriesTrajectory = getAreasInHydroSeriesModFiles(seriesTrajectory.getId());
-            boolean isHydroSeriesTrajectoryHasTPAreas = areasTPFiles.containsAll(areasModInHydroSeriesTrajectory);
+            boolean isHydroSeriesTrajectoryHasTPAreas = containsAllIgnoreCase(areasTPFiles, areasModInHydroSeriesTrajectory);
 
             if (!isHydroSeriesTrajectoryHasTPAreas) {
                 String childLabel = Objects.equals(childTrajectoryType, TrajectoryType.HYDRO_ALLOCATION.name()) ? "hydroAllocation" : "hydroParameters";
@@ -81,9 +81,14 @@ public class HydroCoherenceCheckServiceImpl implements HydroCoherenceCheckServic
         List<HydroSeriesEntity> hydroSeriesEntities = hydroSeriesRepository.findHydroSeriesEntitiesByTrajectoryId(trajectoryId);
         return hydroSeriesEntities.stream()
                 .map(HydroSeriesEntity::getTsName)
-                .filter(file -> file.startsWith(HYDRO_SERIES_INFLOWS_MOD))
-                .map(s -> s.split("_")[1])
+                .filter(file -> file.toLowerCase(Locale.ROOT).startsWith(HYDRO_SERIES_INFLOWS_MOD))
+                .map(s -> s.split("_")[1].toUpperCase(Locale.ROOT))
                 .toList();
+    }
+
+    private boolean containsAllIgnoreCase(List<String> container, List<String> elements) {
+        return elements.stream()
+                .allMatch(e -> container.stream().anyMatch(c -> c.equalsIgnoreCase(e)));
     }
 
     public List<String> getAreasInHydroAllocationAreas(Integer trajectoryId) {

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/hydro/impl/HydroFileProcessorServiceImpl.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/hydro/impl/HydroFileProcessorServiceImpl.java
@@ -122,13 +122,20 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
 
         for (var area : areaList) {
             var filesName = processRequiredSeries(trajectoryFilePath, horizon, area, studyAreas, isPsp);
-            if (!checkHydroFileConsistency(filesName, area, horizon, missingModFiles)) hasOnlyRorFile = false;
-            filesNameFinal.addAll(filesName);
+            boolean isRorOnly = checkHydroFileConsistency(filesName, area, horizon, missingModFiles);
+            if (isRorOnly) {
+                filesName.stream()
+                        .filter(f -> f.startsWith(HYDRO_SERIES_INFLOWS_ROR + '_'))
+                        .forEach(filesNameFinal::add);
+            } else {
+                hasOnlyRorFile = false;
+                filesNameFinal.addAll(filesName);
+            }
         }
 
         String maxPowerFileName = null;
         if (!hasOnlyRorFile) {
-            validateModFiles(missingModFiles, trajectoryToUse);
+            validateModFiles(missingModFiles, trajectoryToUse, isPsp);
             List<String> areasInHydroSeriesModFiles = filesNameFinal.stream()
                     .filter(file -> file.startsWith(HYDRO_SERIES_INFLOWS_MOD))
                     .map(s -> s.split("_")[1])
@@ -141,7 +148,7 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
 
         if (filesNameFinal.isEmpty()) {
             throw BusinessException.builder()
-                    .message("Missing files in trajectory " + trajectoryType.name())
+                    .message("Missing files in " + HydroTypeHelper.getSeriesLabel(isPsp) + " trajectory")
                     .httpStatus(HttpStatus.BAD_REQUEST)
                     .build();
         }
@@ -204,7 +211,7 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
                 }
                 case null ->
                         throw BusinessException.builder()
-                                .message("Could not process " + trajectoryType.name() + " trajectory")
+                                .message("Could not process " + HydroTypeHelper.getTechnicalParametersLabel(isPsp) + " trajectory")
                                 .httpStatus(HttpStatus.BAD_REQUEST)
                                 .build();
             }
@@ -242,13 +249,14 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
             List<String> studyAreas
     ) throws IOException {
 
-        Path fileMaxPowerPath = findMaxPowerFile(trajectoryFilePath);
-        
+        boolean isPsp = HydroTypeHelper.isPsp(trajectoryType);
+        Path fileMaxPowerPath = findMaxPowerFile(trajectoryFilePath, isPsp);
+
         validateMaxPowerFile(trajectoryType, fileMaxPowerPath, trajectoryToUse, horizon, areaParam, studyAreas, areasInHydroSeriesModFiles);
         return fileMaxPowerPath.getFileName().toString();
     }
 
-    private Path findMaxPowerFile(Path trajectoryFilePath) throws BusinessException {
+    private Path findMaxPowerFile(Path trajectoryFilePath, boolean isPsp) throws BusinessException {
         String trajectoryToUse = trajectoryFilePath.getFileName().toString();
         try (Stream<Path> stream = Files.list(trajectoryFilePath)) {
             List<Path> files = stream
@@ -258,7 +266,7 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
             if (files.isEmpty()) {
                 throw BusinessException.builder()
                         .errorMessageArguments(List.of(trajectoryToUse))
-                        .message("Missing maxpower file (maxpower_{0}) in Hydro Series trajectory {0}")
+                        .message("Missing maxpower file (maxpower_{0}) in " + HydroTypeHelper.getSeriesLabel(isPsp) + " trajectory {0}")
                         .httpStatus(HttpStatus.BAD_REQUEST)
                         .build();
             }
@@ -303,7 +311,7 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
             String parametersLabel = isPsp ? "PSP_Virtual hydroParameters" : "hydroParameters";
             throw BusinessException.builder()
                     .errorMessageArguments(List.of(allocationLabel, parametersLabel, trajectoryFilePath.getFileName().toString()))
-                    .message("Missing file {0} or {1} in trajectory Hydro Technical parameters trajectory {2}")
+                    .message("Missing file {0} or {1} in trajectory " + HydroTypeHelper.getTechnicalParametersLabel(isPsp) + " trajectory {2}")
                     .httpStatus(HttpStatus.BAD_REQUEST)
                     .build();
         }
@@ -357,31 +365,20 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
         return filesName;
     }
 
-    private boolean checkHydroFileConsistency(List<String> filesName, String area, String horizon, List<String> missingModFiles) throws BusinessException {
-        boolean hasMingen = false;
-        boolean hasReservoirLevels = false;
-        boolean hasMod = false;
+    private boolean checkHydroFileConsistency(List<String> filesName, String area, String horizon, List<String> missingModFiles) {
+        boolean hasMingen = filesName.stream().anyMatch(f -> f.startsWith(HYDRO_SERIES_MINGEN + '_' + area));
+        boolean hasReservoirLevels = filesName.stream().anyMatch(f -> f.startsWith(HYDRO_SERIES_RESERVOIR_LEVELS + '_' + area));
+        boolean hasMod = filesName.stream().anyMatch(f -> f.startsWith(HYDRO_SERIES_INFLOWS_MOD + '_' + area));
 
-        for (String fileName : filesName) {
-            if (fileName.startsWith(HYDRO_SERIES_MINGEN+'_'+area)) {
-                hasMingen = true;
-            }
-            if (fileName.startsWith(HYDRO_SERIES_RESERVOIR_LEVELS+'_'+area)) {
-                hasReservoirLevels = true;
-            }
-            if (filesName.stream().anyMatch(name -> name.startsWith(HYDRO_SERIES_INFLOWS_MOD+'_'+area))) {
-                hasMod = true;
-            }
-            if (((hasMingen && !hasMod) || (hasReservoirLevels && !hasMod)) && !fileName.startsWith(HYDRO_SERIES_INFLOWS_ROR+'_'+area)) {
-                String modFileName = HYDRO_SERIES_INFLOWS_MOD + "_" + area + "_" + horizon + ".csv";
-
-                if (!missingModFiles.contains(modFileName)) {
-                    missingModFiles.add(modFileName);
-                }
+        if ((hasMingen || hasReservoirLevels) && !hasMod) {
+            String modFileName = HYDRO_SERIES_INFLOWS_MOD + "_" + area + "_" + horizon + ".csv";
+            if (!missingModFiles.contains(modFileName)) {
+                missingModFiles.add(modFileName);
             }
         }
 
-        return !hasMingen && !hasMod && !hasReservoirLevels;
+        // true = only ror. if neither mingen nor reservoir_levels are present then we look at ror
+        return !hasMingen && !hasReservoirLevels;
     }
 
     private boolean isPathWithinDirectory(Path parentDirectoryRealPath, Path childRealPath) {
@@ -458,8 +455,9 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
 
         // Validate that the file path is trusted and points to a regular file
         if (filePath == null || !Files.isRegularFile(filePath)) {
+            boolean isPsp = HydroTypeHelper.isPsp(trajectoryType);
             throw BusinessException.builder()
-                    .message("Missing maxpower file in trajectory " + trajectoryType.name())
+                    .message("Missing maxpower file in " + HydroTypeHelper.getSeriesLabel(isPsp) + " trajectory")
                     .httpStatus(HttpStatus.BAD_REQUEST)
                     .build();
         }
@@ -828,11 +826,11 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
         return true;
     }
     
-    public void validateModFiles(List<String> missingModFiles, String trajectoryToUse) {
+    public void validateModFiles(List<String> missingModFiles, String trajectoryToUse, boolean isPsp) {
         if (!missingModFiles.isEmpty()) {
             throw BusinessException.builder()
                     .errorMessageArguments(List.of(String.join(", ", missingModFiles), trajectoryToUse))
-                    .message("Missing MOD file ({0}) in trajectory Hydro Series trajectory {1}")
+                    .message("Missing mod file ({0}) in trajectory " + HydroTypeHelper.getSeriesLabel(isPsp) + " trajectory {1}")
                     .httpStatus(HttpStatus.BAD_REQUEST)
                     .build();
         }

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/hydro/impl/HydroFileProcessorServiceImpl.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/hydro/impl/HydroFileProcessorServiceImpl.java
@@ -77,7 +77,6 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
     protected static final String[] REQUIRED_HYDRO_PARAMETERS_NUMERIC_COLUMNS = {
             INTER_DAILY_BREAKDOWN_COLUMN, INTER_DAILY_MODULATION_COLUMN, INTER_MONTHLY_BREAKDOWN_COLUMN, INITIALIZE_RESERVOIR_DATE_COLUMN, PUMPING_EFFICIENCY_COLUMN, RESERVOIR_CAPACITY_COLUMN};
     protected static final String[] REQUIRED_HYDRO_PARAMETERS_BOOLEAN_COLUMNS = {RESERVOIR_COLUMN, FOLLOW_LOAD_COLUMN, USE_WATER_COLUMN};
-    private static final String TRAJECTORY_SUFFIX = " trajectory";
 
     public record TechnicalParametersProcessingContext(
             Path filePath,
@@ -149,7 +148,8 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
 
         if (filesNameFinal.isEmpty()) {
             throw BusinessException.builder()
-                    .message("Missing files in " + HydroTypeHelper.getSeriesLabel(isPsp) + TRAJECTORY_SUFFIX)
+                    .errorMessageArguments(List.of(HydroTypeHelper.getSeriesLabel(isPsp)))
+                    .message("Missing files in {0} trajectory")
                     .httpStatus(HttpStatus.BAD_REQUEST)
                     .build();
         }
@@ -212,7 +212,8 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
                 }
                 case null ->
                         throw BusinessException.builder()
-                                .message("Could not process " + HydroTypeHelper.getTechnicalParametersLabel(isPsp) + TRAJECTORY_SUFFIX)
+                                .errorMessageArguments(List.of(HydroTypeHelper.getTechnicalParametersLabel(isPsp)))
+                                .message("Could not process {0} trajectory")
                                 .httpStatus(HttpStatus.BAD_REQUEST)
                                 .build();
             }
@@ -266,8 +267,8 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
 
             if (files.isEmpty()) {
                 throw BusinessException.builder()
-                        .errorMessageArguments(List.of(trajectoryToUse))
-                        .message("Missing maxpower file (maxpower_{0}) in " + HydroTypeHelper.getSeriesLabel(isPsp) + " trajectory {0}")
+                        .errorMessageArguments(List.of(HydroTypeHelper.getSeriesLabel(isPsp), trajectoryToUse))
+                        .message("Missing maxpower file (maxpower_{1}) in {0} trajectory {1}")
                         .httpStatus(HttpStatus.BAD_REQUEST)
                         .build();
             }
@@ -312,8 +313,8 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
             String allocationLabel = isPsp ? "PSP_Virtual hydroAllocation" : "hydroAllocation";
             String parametersLabel = isPsp ? "PSP_Virtual hydroParameters" : "hydroParameters";
             throw BusinessException.builder()
-                    .errorMessageArguments(List.of(allocationLabel, parametersLabel, trajectoryFilePath.getFileName().toString()))
-                    .message("Missing file {0} or {1} in trajectory " + HydroTypeHelper.getTechnicalParametersLabel(isPsp) + " trajectory {2}")
+                    .errorMessageArguments(List.of(allocationLabel, parametersLabel, HydroTypeHelper.getTechnicalParametersLabel(isPsp), trajectoryFilePath.getFileName().toString()))
+                    .message("Missing file {0} or {1} in {2} trajectory {3}")
                     .httpStatus(HttpStatus.BAD_REQUEST)
                     .build();
         }
@@ -339,8 +340,8 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
             Path seriesDirectoryPath = trajectoryFilePath.resolve(directory).normalize();
             if (!Files.isDirectory(seriesDirectoryPath)) {
                 throw BusinessException.builder()
-                        .errorMessageArguments(List.of(directory, trajectoryFilePath.getFileName().toString()))
-                        .message("Missing folder {0} in " + HydroTypeHelper.getSeriesLabel(isPsp) + TRAJECTORY_SUFFIX + " {1}")
+                        .errorMessageArguments(List.of(directory, HydroTypeHelper.getSeriesLabel(isPsp), trajectoryFilePath.getFileName().toString()))
+                        .message("Missing folder {0} in {1} trajectory {2}")
                         .httpStatus(HttpStatus.BAD_REQUEST)
                         .build();
             }
@@ -348,8 +349,8 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
 
             if (!isPathWithinDirectory(realTrajectoryFilePath, realSeriesDirectoryPath)) {
                 throw BusinessException.builder()
-                        .errorMessageArguments(List.of(directory, trajectoryFilePath.getFileName().toString()))
-                        .message("Path for folder {0} is out of trajectory directory in " + HydroTypeHelper.getSeriesLabel(isPsp) + TRAJECTORY_SUFFIX + " {1}")
+                        .errorMessageArguments(List.of(directory, HydroTypeHelper.getSeriesLabel(isPsp), trajectoryFilePath.getFileName().toString()))
+                        .message("Path for folder {0} is out of trajectory directory in {1} trajectory {2}")
                         .httpStatus(HttpStatus.BAD_REQUEST)
                         .build();
             }
@@ -459,7 +460,8 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
         if (filePath == null || !Files.isRegularFile(filePath)) {
             boolean isPsp = HydroTypeHelper.isPsp(trajectoryType);
             throw BusinessException.builder()
-                    .message("Missing maxpower file in " + HydroTypeHelper.getSeriesLabel(isPsp) + TRAJECTORY_SUFFIX)
+                    .errorMessageArguments(List.of(HydroTypeHelper.getSeriesLabel(isPsp)))
+                    .message("Missing maxpower file in {0} trajectory")
                     .httpStatus(HttpStatus.BAD_REQUEST)
                     .build();
         }
@@ -847,8 +849,8 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
     public void validateModFiles(List<String> missingModFiles, String trajectoryToUse, boolean isPsp) {
         if (!missingModFiles.isEmpty()) {
             throw BusinessException.builder()
-                    .errorMessageArguments(List.of(String.join(", ", missingModFiles), trajectoryToUse))
-                    .message("Missing mod file ({0}) in " + HydroTypeHelper.getSeriesLabel(isPsp) + TRAJECTORY_SUFFIX + " {1}")
+                    .errorMessageArguments(List.of(String.join(", ", missingModFiles), HydroTypeHelper.getSeriesLabel(isPsp), trajectoryToUse))
+                    .message("Missing mod file ({0}) in {1} trajectory {2}")
                     .httpStatus(HttpStatus.BAD_REQUEST)
                     .build();
         }

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/hydro/impl/HydroFileProcessorServiceImpl.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/hydro/impl/HydroFileProcessorServiceImpl.java
@@ -126,7 +126,7 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
             boolean isRorOnly = checkHydroFileConsistency(filesName, area, horizon, missingModFiles);
             if (isRorOnly) {
                 filesName.stream()
-                        .filter(f -> f.startsWith(HYDRO_SERIES_INFLOWS_ROR + '_'))
+                        .filter(f -> startsWithIgnoreCase(f, HYDRO_SERIES_INFLOWS_ROR + '_'))
                         .forEach(filesNameFinal::add);
             } else {
                 hasOnlyRorFile = false;
@@ -138,8 +138,8 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
         if (!hasOnlyRorFile) {
             validateModFiles(missingModFiles, trajectoryToUse, isPsp);
             List<String> areasInHydroSeriesModFiles = filesNameFinal.stream()
-                    .filter(file -> file.startsWith(HYDRO_SERIES_INFLOWS_MOD))
-                    .map(s -> s.split("_")[1])
+                    .filter(file -> startsWithIgnoreCase(file, HYDRO_SERIES_INFLOWS_MOD))
+                    .map(s -> s.split("_")[1].toUpperCase(Locale.ROOT))
                     .toList();
             maxPowerFileName = processMaxPowerFile(trajectoryType, trajectoryFilePath, trajectoryToUse, horizon, areaParam, areasInHydroSeriesModFiles, studyAreas);
             if (studyId != null) {
@@ -261,7 +261,7 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
         String trajectoryToUse = trajectoryFilePath.getFileName().toString();
         try (Stream<Path> stream = Files.list(trajectoryFilePath)) {
             List<Path> files = stream
-                .filter(p -> p.getFileName().toString().startsWith(HYDRO_SERIES_PREFIX_MAX_POWER+trajectoryToUse))
+                .filter(p -> startsWithIgnoreCase(p.getFileName().toString(), HYDRO_SERIES_PREFIX_MAX_POWER + trajectoryToUse))
                 .toList();
 
             if (files.isEmpty()) {
@@ -291,8 +291,9 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
                         ? HYDRO_TECHNICAL_PREFIX_ALLOCATION
                         : HYDRO_TECHNICAL_PREFIX_PARAMETERS;
 
+                String expectedPrefix = prefix + trajectoryFilePath.getFileName().toString();
                 Path match = allFiles.stream()
-                        .filter(p -> p.getFileName().toString().startsWith(prefix+trajectoryFilePath.getFileName().toString()))
+                        .filter(p -> startsWithIgnoreCase(p.getFileName().toString(), expectedPrefix))
                         .findFirst()
                         .orElse(null);
 
@@ -352,7 +353,7 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
                         .httpStatus(HttpStatus.BAD_REQUEST)
                         .build();
             }
-            
+
             List<Path> pathFiles = findSeriesFiles(realSeriesDirectoryPath, horizon, areaParam, config, studyAreas);
             if (pathFiles.isEmpty()) {
                 continue;
@@ -367,12 +368,12 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
     }
 
     private boolean checkHydroFileConsistency(List<String> filesName, String area, String horizon, List<String> missingModFiles) {
-        boolean hasMingen = filesName.stream().anyMatch(f -> f.startsWith(HYDRO_SERIES_MINGEN + '_' + area));
-        boolean hasReservoirLevels = filesName.stream().anyMatch(f -> f.startsWith(HYDRO_SERIES_RESERVOIR_LEVELS + '_' + area));
-        boolean hasMod = filesName.stream().anyMatch(f -> f.startsWith(HYDRO_SERIES_INFLOWS_MOD + '_' + area));
+        boolean hasMingen = filesName.stream().anyMatch(f -> startsWithIgnoreCase(f, HYDRO_SERIES_MINGEN + '_' + area));
+        boolean hasReservoirLevels = filesName.stream().anyMatch(f -> startsWithIgnoreCase(f, HYDRO_SERIES_RESERVOIR_LEVELS + '_' + area));
+        boolean hasMod = filesName.stream().anyMatch(f -> startsWithIgnoreCase(f, HYDRO_SERIES_INFLOWS_MOD + '_' + area));
 
         if ((hasMingen || hasReservoirLevels) && !hasMod) {
-            String modFileName = HYDRO_SERIES_INFLOWS_MOD + "_" + area + "_" + horizon + ".csv";
+            String modFileName = HYDRO_SERIES_INFLOWS_MOD + "_" + area.toLowerCase(Locale.ROOT) + "_" + horizon + ".csv";
             if (!missingModFiles.contains(modFileName)) {
                 missingModFiles.add(modFileName);
             }
@@ -416,22 +417,22 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
         String prefix = String.join("_", Arrays.copyOf(parts, parts.length - 2));
 
         boolean areaMatches = Objects.equals(areaParam, OTHERS_AREA)
-                ? studyAreas.contains(area)
-                : areaParam.equals(area);
+                ? studyAreas.stream().anyMatch(sa -> sa.equalsIgnoreCase(area))
+                : areaParam.equalsIgnoreCase(area);
 
-        return prefixes.contains(prefix)
+        return prefixes.stream().anyMatch(p -> p.equalsIgnoreCase(prefix))
                 && areaMatches
                 && horizon.equals(horizonFile);
     }
     
     private String getFiletype(String fileName) {
-        if (fileName.startsWith(HYDRO_SERIES_INFLOWS_MOD) || fileName.startsWith(HYDRO_SERIES_INFLOWS_ROR)) {
+        if (startsWithIgnoreCase(fileName, HYDRO_SERIES_INFLOWS_MOD) || startsWithIgnoreCase(fileName, HYDRO_SERIES_INFLOWS_ROR)) {
             return HydroSeriesType.INFLOWS.name();
         }
-        if (fileName.startsWith(HYDRO_SERIES_MINGEN)) {
+        if (startsWithIgnoreCase(fileName, HYDRO_SERIES_MINGEN)) {
             return HydroSeriesType.MINGEN.name();
         }
-        if (fileName.startsWith(HYDRO_SERIES_RESERVOIR_LEVELS)) {
+        if (startsWithIgnoreCase(fileName, HYDRO_SERIES_RESERVOIR_LEVELS)) {
             return HydroSeriesType.RESERVOIR_LEVELS.name();
         }
         return null;

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/hydro/impl/HydroFileProcessorServiceImpl.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/hydro/impl/HydroFileProcessorServiceImpl.java
@@ -22,6 +22,7 @@ import java.math.BigDecimal;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import static com.rte_france.antares.datamanager_back.util.Utils.*;
@@ -74,8 +75,9 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
     protected static final String USE_WATER_COLUMN = "use.water";
     protected static final String[] REQUIRED_HYDRO_PARAMETERS_COLUMNS = {
             NODE_COLUMN, INTER_DAILY_BREAKDOWN_COLUMN, INTER_DAILY_MODULATION_COLUMN, INTER_MONTHLY_BREAKDOWN_COLUMN, INITIALIZE_RESERVOIR_DATE_COLUMN,PUMPING_EFFICIENCY_COLUMN, RESERVOIR_COLUMN, RESERVOIR_CAPACITY_COLUMN, FOLLOW_LOAD_COLUMN, USE_WATER_COLUMN};
+    protected static final String[] REQUIRED_HYDRO_PARAMETERS_INTEGER_COLUMNS = {INITIALIZE_RESERVOIR_DATE_COLUMN};
     protected static final String[] REQUIRED_HYDRO_PARAMETERS_NUMERIC_COLUMNS = {
-            INTER_DAILY_BREAKDOWN_COLUMN, INTER_DAILY_MODULATION_COLUMN, INTER_MONTHLY_BREAKDOWN_COLUMN, INITIALIZE_RESERVOIR_DATE_COLUMN, PUMPING_EFFICIENCY_COLUMN, RESERVOIR_CAPACITY_COLUMN};
+            INTER_DAILY_BREAKDOWN_COLUMN, INTER_DAILY_MODULATION_COLUMN, INTER_MONTHLY_BREAKDOWN_COLUMN, PUMPING_EFFICIENCY_COLUMN, RESERVOIR_CAPACITY_COLUMN};
     protected static final String[] REQUIRED_HYDRO_PARAMETERS_BOOLEAN_COLUMNS = {RESERVOIR_COLUMN, FOLLOW_LOAD_COLUMN, USE_WATER_COLUMN};
 
     public record TechnicalParametersProcessingContext(
@@ -683,11 +685,12 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
 
         if (!shouldProcessArea(context, area)) return;
 
-        Object[] numericValues = new Object[] { interDailyBreakdown, interDailyModulation, interMonthlyBreakdown, initializeReservoirDate, pumpingEfficiency, reservoirCapacity };
+        Object[] numericValues = new Object[] { interDailyBreakdown, interDailyModulation, interMonthlyBreakdown, pumpingEfficiency, reservoirCapacity };
         Object[] booleanValues = new Object[] { reservoir, followLoad, useWater };
 
         validateEmptyRequiredColumns(context, REQUIRED_HYDRO_PARAMETERS_NUMERIC_COLUMNS, true, isPsp, numericValues);
         validateEmptyRequiredColumns(context, REQUIRED_HYDRO_PARAMETERS_BOOLEAN_COLUMNS, false, isPsp, booleanValues);
+        validateIntegerColumns(context, REQUIRED_HYDRO_PARAMETERS_INTEGER_COLUMNS, isPsp, initializeReservoirDate);
 
         BigDecimal reservoirCapacityValue = parseDecimal(reservoirCapacity);
 
@@ -696,7 +699,7 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
                 .interDailyBreakdown(parseDecimal(interDailyBreakdown))
                 .interDailyModulation(parseDecimal(interDailyModulation))
                 .interMonthlyBreakdown(parseDecimal(interMonthlyBreakdown))
-                .initializeReservoirDate(parseDecimal(initializeReservoirDate))
+                .initializeReservoirDate(Integer.valueOf(initializeReservoirDate))
                 .pumpingEfficiency(parseDecimal(pumpingEfficiency))
                 .reservoir(reservoir)
                 .reservoirCapacity(reservoirCapacityValue)
@@ -744,18 +747,24 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
             boolean isPsp,
             Object... values
     ) {
+        Predicate<String> validator = isNumeric ? HydroFileProcessorServiceImpl::isDecimal : this::isBooleanStringValue;
+        String columnsLabel = getColumnsLabel(context.getTrajectoryType(), isNumeric);
+        String valuesLabel = isNumeric ? "filled and of numeric type" : "boolean values";
+        validateColumns(context, requiredColumns, columnsLabel, validator, valuesLabel, isPsp, values);
+    }
+
+    private void validateIntegerColumns(ResRowProcessingContext context, String[] requiredColumns, boolean isPsp, Object... values) {
+        String columnsLabel = String.join(", ", requiredColumns);
+        validateColumns(context, requiredColumns, columnsLabel, HydroFileProcessorServiceImpl::isInteger, "an integer", isPsp, values);
+    }
+
+    private void validateColumns(ResRowProcessingContext context, String[] requiredColumns, String columnsLabel, Predicate<String> validator, String valuesLabel, boolean isPsp, Object... values) {
         List<String> missing = new ArrayList<>();
-
         for (int i = 0; i < requiredColumns.length; i++) {
-            if (isValueInvalid(values, i, isNumeric)) {
-                missing.add(requiredColumns[i]);
-            }
+            if (isValueInvalid(values, i, validator)) missing.add(requiredColumns[i]);
         }
-
         if (!missing.isEmpty()) {
-            String columnsLabel = getColumnsLabel(context.getTrajectoryType(), isNumeric);
             String typeLabel = getTypeLabel(context.getTrajectoryType(), isPsp);
-            String valuesLabel = isNumeric ? "filled and of numeric type" : "boolean values";
             throw BusinessException.builder()
                     .errorMessageArguments(List.of(columnsLabel, typeLabel, context.getTrajectoryToUse(), valuesLabel))
                     .message("{0} in the {1} trajectory {2} must be {3}")
@@ -764,12 +773,10 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
         }
     }
 
-    private boolean isValueInvalid(Object[] values, int i, boolean isNumeric) {
-        if (i >= values.length || values[i] == null) {
-            return true;
-        }
+    private boolean isValueInvalid(Object[] values, int i, Predicate<String> validator) {
+        if (i >= values.length || values[i] == null) return true;
         return switch (values[i]) {
-            case String s -> isNumeric ? !isDecimal(s) : !isBooleanStringValue(s);
+            case String s -> !validator.test(s);
             default -> false;
         };
     }
@@ -792,7 +799,7 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
         if (trajectoryType == TrajectoryType.HYDRO_ALLOCATION) {
             return "Allocation column";
         }
-        return isNumeric ? "Column(s) 2 to 6 and 8" : "Column(s) 7, 9 and 10";
+        return isNumeric ? "Column(s) 2 to 4, 6 and 8" : "Column(s) 7, 9 and 10";
     }
 
     private String getTypeLabel(TrajectoryType trajectoryType, boolean isPsp) {

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/hydro/impl/HydroFileProcessorServiceImpl.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/hydro/impl/HydroFileProcessorServiceImpl.java
@@ -686,15 +686,15 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
         validateEmptyRequiredColumns(context, REQUIRED_HYDRO_PARAMETERS_NUMERIC_COLUMNS, true, isPsp, numericValues);
         validateEmptyRequiredColumns(context, REQUIRED_HYDRO_PARAMETERS_BOOLEAN_COLUMNS, false, isPsp, booleanValues);
 
-        BigDecimal reservoirCapacityValue = BigDecimal.valueOf(Long.parseLong(reservoirCapacity));
+        BigDecimal reservoirCapacityValue = parseDecimal(reservoirCapacity);
 
         HydroParametersEntity entity = HydroParametersEntity.builder()
                 .node(area)
-                .interDailyBreakdown(Integer.parseInt(interDailyBreakdown))
-                .interDailyModulation(Integer.valueOf(interDailyModulation))
-                .interMonthlyBreakdown(Integer.valueOf(interMonthlyBreakdown))
-                .initializeReservoirDate(Integer.valueOf(initializeReservoirDate))
-                .pumpingEfficiency(Integer.valueOf(pumpingEfficiency))
+                .interDailyBreakdown(parseDecimal(interDailyBreakdown))
+                .interDailyModulation(parseDecimal(interDailyModulation))
+                .interMonthlyBreakdown(parseDecimal(interMonthlyBreakdown))
+                .initializeReservoirDate(parseDecimal(initializeReservoirDate))
+                .pumpingEfficiency(parseDecimal(pumpingEfficiency))
                 .reservoir(reservoir)
                 .reservoirCapacity(reservoirCapacityValue)
                 .followLoad(followLoad)
@@ -766,9 +766,23 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
             return true;
         }
         return switch (values[i]) {
-            case String s -> isNumeric ? !isInteger(s) : !isBooleanStringValue(s);
+            case String s -> isNumeric ? !isDecimal(s) : !isBooleanStringValue(s);
             default -> false;
         };
+    }
+
+    public static boolean isDecimal(String s) {
+        if (s == null) return false;
+        try {
+            new BigDecimal(s.replace(",", "."));
+            return true;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    private static BigDecimal parseDecimal(String s) {
+        return new BigDecimal(s.replace(",", "."));
     }
 
     private String getColumnsLabel(TrajectoryType trajectoryType, boolean isNumeric) {

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/hydro/impl/HydroFileProcessorServiceImpl.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/hydro/impl/HydroFileProcessorServiceImpl.java
@@ -77,6 +77,7 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
     protected static final String[] REQUIRED_HYDRO_PARAMETERS_NUMERIC_COLUMNS = {
             INTER_DAILY_BREAKDOWN_COLUMN, INTER_DAILY_MODULATION_COLUMN, INTER_MONTHLY_BREAKDOWN_COLUMN, INITIALIZE_RESERVOIR_DATE_COLUMN, PUMPING_EFFICIENCY_COLUMN, RESERVOIR_CAPACITY_COLUMN};
     protected static final String[] REQUIRED_HYDRO_PARAMETERS_BOOLEAN_COLUMNS = {RESERVOIR_COLUMN, FOLLOW_LOAD_COLUMN, USE_WATER_COLUMN};
+    private static final String TRAJECTORY_SUFFIX = " trajectory";
 
     public record TechnicalParametersProcessingContext(
             Path filePath,
@@ -148,7 +149,7 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
 
         if (filesNameFinal.isEmpty()) {
             throw BusinessException.builder()
-                    .message("Missing files in " + HydroTypeHelper.getSeriesLabel(isPsp) + " trajectory")
+                    .message("Missing files in " + HydroTypeHelper.getSeriesLabel(isPsp) + TRAJECTORY_SUFFIX)
                     .httpStatus(HttpStatus.BAD_REQUEST)
                     .build();
         }
@@ -211,7 +212,7 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
                 }
                 case null ->
                         throw BusinessException.builder()
-                                .message("Could not process " + HydroTypeHelper.getTechnicalParametersLabel(isPsp) + " trajectory")
+                                .message("Could not process " + HydroTypeHelper.getTechnicalParametersLabel(isPsp) + TRAJECTORY_SUFFIX)
                                 .httpStatus(HttpStatus.BAD_REQUEST)
                                 .build();
             }
@@ -338,7 +339,7 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
             if (!Files.isDirectory(seriesDirectoryPath)) {
                 throw BusinessException.builder()
                         .errorMessageArguments(List.of(directory, trajectoryFilePath.getFileName().toString()))
-                        .message("Missing folder {0} in " + HydroTypeHelper.getSeriesLabel(isPsp) + " trajectory {1}")
+                        .message("Missing folder {0} in " + HydroTypeHelper.getSeriesLabel(isPsp) + TRAJECTORY_SUFFIX + " {1}")
                         .httpStatus(HttpStatus.BAD_REQUEST)
                         .build();
             }
@@ -347,7 +348,7 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
             if (!isPathWithinDirectory(realTrajectoryFilePath, realSeriesDirectoryPath)) {
                 throw BusinessException.builder()
                         .errorMessageArguments(List.of(directory, trajectoryFilePath.getFileName().toString()))
-                        .message("Path for folder {0} is out of trajectory directory in " + HydroTypeHelper.getSeriesLabel(isPsp) + " trajectory {1}")
+                        .message("Path for folder {0} is out of trajectory directory in " + HydroTypeHelper.getSeriesLabel(isPsp) + TRAJECTORY_SUFFIX + " {1}")
                         .httpStatus(HttpStatus.BAD_REQUEST)
                         .build();
             }
@@ -457,7 +458,7 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
         if (filePath == null || !Files.isRegularFile(filePath)) {
             boolean isPsp = HydroTypeHelper.isPsp(trajectoryType);
             throw BusinessException.builder()
-                    .message("Missing maxpower file in " + HydroTypeHelper.getSeriesLabel(isPsp) + " trajectory")
+                    .message("Missing maxpower file in " + HydroTypeHelper.getSeriesLabel(isPsp) + TRAJECTORY_SUFFIX)
                     .httpStatus(HttpStatus.BAD_REQUEST)
                     .build();
         }
@@ -830,7 +831,7 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
         if (!missingModFiles.isEmpty()) {
             throw BusinessException.builder()
                     .errorMessageArguments(List.of(String.join(", ", missingModFiles), trajectoryToUse))
-                    .message("Missing mod file ({0}) in trajectory " + HydroTypeHelper.getSeriesLabel(isPsp) + " trajectory {1}")
+                    .message("Missing mod file ({0}) in " + HydroTypeHelper.getSeriesLabel(isPsp) + TRAJECTORY_SUFFIX + " {1}")
                     .httpStatus(HttpStatus.BAD_REQUEST)
                     .build();
         }

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/hydro/impl/HydroFileProcessorServiceImpl.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/hydro/impl/HydroFileProcessorServiceImpl.java
@@ -554,10 +554,12 @@ public class HydroFileProcessorServiceImpl implements HydroFileProcessorService 
 
             HydroTechnicalParametersRowProcessingResult result = processRows(sheet, context, ctx);
 
-            try {
-                validateAreas(ctx.studyAreas(), ctx.areaParam(), result.fileAreas(), ctx.trajectoryToUse(), ctx.trajectoryType());
-            } catch (BusinessException e) {
-                throw applyPspLabel(e, label, isPsp);
+            if (ctx.trajectoryType() != TrajectoryType.HYDRO_ALLOCATION) {
+                try {
+                    validateAreas(ctx.studyAreas(), ctx.areaParam(), result.fileAreas(), ctx.trajectoryToUse(), ctx.trajectoryType());
+                } catch (BusinessException e) {
+                    throw applyPspLabel(e, label, isPsp);
+                }
             }
 
             return result;

--- a/src/main/java/com/rte_france/antares/datamanager_back/util/Utils.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/util/Utils.java
@@ -994,7 +994,7 @@ public class Utils {
     }
 
     public static void validateSelectedAreaPresence(String areaParam, List<String> fileAreas, TrajectoryType trajectoryType, String trajectoryToUse) {
-        if (!areaParam.isBlank() && !OTHERS_AREA.equals(areaParam) && !fileAreas.contains(areaParam.toUpperCase())) {
+        if (!areaParam.isBlank() && !OTHERS_AREA.equals(areaParam) && fileAreas.stream().noneMatch(fa -> fa.equalsIgnoreCase(areaParam))) {
             throwTrajectoryValidationException(
                     trajectoryType.name(),
                     "Selected area {0} is not present in the 'node' column of {1} trajectory {2}",
@@ -1007,8 +1007,11 @@ public class Utils {
     }
 
     public static void validateSelectedOthersAreaPresence(List<String> areasToCompare, List<String> fileAreas, TrajectoryType trajectoryType, String trajectoryToUse) {
-        List<String> missingAreas = new ArrayList<>(areasToCompare);
-        missingAreas.removeAll(fileAreas);
+        Set<String> fileAreasLookup = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        fileAreasLookup.addAll(fileAreas);
+        List<String> missingAreas = areasToCompare.stream()
+                .filter(a -> !fileAreasLookup.contains(a))
+                .toList();
 
         if (!missingAreas.isEmpty()) {
             throwTrajectoryValidationException(

--- a/src/main/resources/db/changelog/1.1.0/V55-alter-hydro-parameters-decimal-columns.sql
+++ b/src/main/resources/db/changelog/1.1.0/V55-alter-hydro-parameters-decimal-columns.sql
@@ -1,0 +1,9 @@
+-- liquibase formatted sql
+-- changeset salemsd:110V055-1
+
+ALTER TABLE hydro_parameters
+    ALTER COLUMN inter_daily_breakdown     TYPE NUMERIC,
+    ALTER COLUMN inter_daily_modulation    TYPE NUMERIC,
+    ALTER COLUMN inter_monthly_breakdown   TYPE NUMERIC,
+    ALTER COLUMN initialize_reservoir_date TYPE NUMERIC,
+    ALTER COLUMN pumping_efficiency        TYPE NUMERIC;

--- a/src/main/resources/db/changelog/1.1.0/V55-alter-hydro-parameters-decimal-columns.sql
+++ b/src/main/resources/db/changelog/1.1.0/V55-alter-hydro-parameters-decimal-columns.sql
@@ -1,9 +1,8 @@
 -- liquibase formatted sql
 -- changeset salemsd:110V055-1
 
-ALTER TABLE hydro_parameters
-    ALTER COLUMN inter_daily_breakdown     TYPE NUMERIC,
-    ALTER COLUMN inter_daily_modulation    TYPE NUMERIC,
-    ALTER COLUMN inter_monthly_breakdown   TYPE NUMERIC,
-    ALTER COLUMN initialize_reservoir_date TYPE NUMERIC,
-    ALTER COLUMN pumping_efficiency        TYPE NUMERIC;
+ALTER TABLE hydro_parameters ALTER COLUMN inter_daily_breakdown     TYPE NUMERIC;
+ALTER TABLE hydro_parameters ALTER COLUMN inter_daily_modulation    TYPE NUMERIC;
+ALTER TABLE hydro_parameters ALTER COLUMN inter_monthly_breakdown   TYPE NUMERIC;
+ALTER TABLE hydro_parameters ALTER COLUMN initialize_reservoir_date TYPE NUMERIC;
+ALTER TABLE hydro_parameters ALTER COLUMN pumping_efficiency        TYPE NUMERIC;

--- a/src/main/resources/db/changelog/1.1.0/V55-alter-hydro-parameters-decimal-columns.sql
+++ b/src/main/resources/db/changelog/1.1.0/V55-alter-hydro-parameters-decimal-columns.sql
@@ -4,5 +4,4 @@
 ALTER TABLE hydro_parameters ALTER COLUMN inter_daily_breakdown     TYPE NUMERIC;
 ALTER TABLE hydro_parameters ALTER COLUMN inter_daily_modulation    TYPE NUMERIC;
 ALTER TABLE hydro_parameters ALTER COLUMN inter_monthly_breakdown   TYPE NUMERIC;
-ALTER TABLE hydro_parameters ALTER COLUMN initialize_reservoir_date TYPE NUMERIC;
 ALTER TABLE hydro_parameters ALTER COLUMN pumping_efficiency        TYPE NUMERIC;

--- a/src/main/resources/db/changelog/1.1.0/db.changelog-1.1.0.yaml
+++ b/src/main/resources/db/changelog/1.1.0/db.changelog-1.1.0.yaml
@@ -114,3 +114,5 @@ databaseChangeLog:
       file: classpath*:db/changelog/1.1.0/V53-add_ocgt_to_thermal_technology.sql
   - include:
       file: classpath*:db/changelog/1.1.0/V54-drop-hvdc-column-in-links-add-to-scenario.sql
+  - include:
+      file: classpath*:db/changelog/1.1.0/V55-alter-hydro-parameters-decimal-columns.sql

--- a/src/test/java/com/rte_france/antares/datamanager_back/mapper/HydroMapperTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/mapper/HydroMapperTest.java
@@ -40,7 +40,7 @@ class HydroMapperTest {
         assertThat(result.getProperties().getInterDailyModulation()).isEqualByComparingTo(new BigDecimal("2"));
         assertThat(result.getProperties().getInterMonthlyBreakdown()).isEqualByComparingTo(new BigDecimal("3"));
         assertThat(result.getProperties().getReservoirManagement()).isTrue();
-        assertThat(result.getProperties().getReservoirCapacity()).isEqualTo(5000);
+        assertThat(result.getProperties().getReservoirCapacity()).isEqualByComparingTo(new BigDecimal("5000"));
         assertThat(result.getProperties().getPumpingEfficiency()).isEqualByComparingTo(new BigDecimal("90"));
         assertThat(result.getProperties().getInitializeReservoirDate()).isEqualByComparingTo(new BigDecimal("7"));
         assertThat(result.getProperties().getUseWater()).isFalse();
@@ -60,14 +60,14 @@ class HydroMapperTest {
     }
 
     @Test
-    void mapToHydroGenerationDTO_shouldTruncateReservoirCapacityDecimal() {
+    void mapToHydroGenerationDTO_shouldMapReservoirCapacityDecimal() {
         HydroParametersEntity entity = HydroParametersEntity.builder()
                 .reservoirCapacity(new BigDecimal("1999.99"))
                 .build();
 
         HydroGenerationDTO result = HydroMapper.mapToHydroGenerationDTO(entity);
 
-        assertThat(result.getProperties().getReservoirCapacity()).isEqualTo(1999);
+        assertThat(result.getProperties().getReservoirCapacity()).isEqualByComparingTo(new BigDecimal("1999.99"));
     }
 
     @Test

--- a/src/test/java/com/rte_france/antares/datamanager_back/mapper/HydroMapperTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/mapper/HydroMapperTest.java
@@ -28,7 +28,7 @@ class HydroMapperTest {
                 .reservoir(true)
                 .reservoirCapacity(new BigDecimal("5000"))
                 .pumpingEfficiency(new BigDecimal("90"))
-                .initializeReservoirDate(new BigDecimal("7"))
+                .initializeReservoirDate(7)
                 .useWater(false)
                 .build();
 
@@ -42,7 +42,7 @@ class HydroMapperTest {
         assertThat(result.getProperties().getReservoirManagement()).isTrue();
         assertThat(result.getProperties().getReservoirCapacity()).isEqualByComparingTo(new BigDecimal("5000"));
         assertThat(result.getProperties().getPumpingEfficiency()).isEqualByComparingTo(new BigDecimal("90"));
-        assertThat(result.getProperties().getInitializeReservoirDate()).isEqualByComparingTo(new BigDecimal("7"));
+        assertThat(result.getProperties().getInitializeReservoirDate()).isEqualTo(7);
         assertThat(result.getProperties().getUseWater()).isFalse();
     }
 

--- a/src/test/java/com/rte_france/antares/datamanager_back/mapper/HydroMapperTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/mapper/HydroMapperTest.java
@@ -22,13 +22,13 @@ class HydroMapperTest {
     void mapToHydroGenerationDTO_shouldMapAllFields() {
         HydroParametersEntity entity = HydroParametersEntity.builder()
                 .followLoad(true)
-                .interDailyBreakdown(1)
-                .interDailyModulation(2)
-                .interMonthlyBreakdown(3)
+                .interDailyBreakdown(new BigDecimal("1"))
+                .interDailyModulation(new BigDecimal("2"))
+                .interMonthlyBreakdown(new BigDecimal("3"))
                 .reservoir(true)
                 .reservoirCapacity(new BigDecimal("5000"))
-                .pumpingEfficiency(90)
-                .initializeReservoirDate(7)
+                .pumpingEfficiency(new BigDecimal("90"))
+                .initializeReservoirDate(new BigDecimal("7"))
                 .useWater(false)
                 .build();
 
@@ -36,13 +36,13 @@ class HydroMapperTest {
 
         assertThat(result).isNotNull();
         assertThat(result.getProperties().getFollowLoadModulation()).isTrue();
-        assertThat(result.getProperties().getInterDailyBreakdown()).isEqualTo(1);
-        assertThat(result.getProperties().getInterDailyModulation()).isEqualTo(2);
-        assertThat(result.getProperties().getInterMonthlyBreakdown()).isEqualTo(3);
+        assertThat(result.getProperties().getInterDailyBreakdown()).isEqualByComparingTo(new BigDecimal("1"));
+        assertThat(result.getProperties().getInterDailyModulation()).isEqualByComparingTo(new BigDecimal("2"));
+        assertThat(result.getProperties().getInterMonthlyBreakdown()).isEqualByComparingTo(new BigDecimal("3"));
         assertThat(result.getProperties().getReservoirManagement()).isTrue();
         assertThat(result.getProperties().getReservoirCapacity()).isEqualTo(5000);
-        assertThat(result.getProperties().getPumpingEfficiency()).isEqualTo(90);
-        assertThat(result.getProperties().getInitializeReservoirDate()).isEqualTo(7);
+        assertThat(result.getProperties().getPumpingEfficiency()).isEqualByComparingTo(new BigDecimal("90"));
+        assertThat(result.getProperties().getInitializeReservoirDate()).isEqualByComparingTo(new BigDecimal("7"));
         assertThat(result.getProperties().getUseWater()).isFalse();
     }
 

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/HydroFileProcessorServiceImplTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/HydroFileProcessorServiceImplTest.java
@@ -539,7 +539,7 @@ class HydroFileProcessorServiceImplTest {
                 service.processHydroSeriesFile(TrajectoryType.HYDRO_SERIES, TRAJ, HORIZON, 1, AREA_FR, false));
 
         assertEquals(HttpStatus.BAD_REQUEST, exception.getHttpStatus());
-        assertTrue(exception.getMessage().contains("Missing mod file ({0}) in trajectory Hydro Series trajectory {1}"));
+        assertTrue(exception.getMessage().contains("Missing mod file ({0}) in Hydro Series trajectory {1}"));
     }
 
     @Test
@@ -564,7 +564,7 @@ class HydroFileProcessorServiceImplTest {
                 service.processHydroSeriesFile(TrajectoryType.HYDRO_SERIES, TRAJ, HORIZON, 1, AREA_FR, false));
 
         assertEquals(HttpStatus.BAD_REQUEST, exception.getHttpStatus());
-        assertTrue(exception.getMessage().contains("Missing mod file ({0}) in trajectory Hydro Series trajectory {1}"));
+        assertTrue(exception.getMessage().contains("Missing mod file ({0}) in Hydro Series trajectory {1}"));
     }
 
     // -------------------------------------------------------------------------

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/HydroFileProcessorServiceImplTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/HydroFileProcessorServiceImplTest.java
@@ -84,11 +84,15 @@ class HydroFileProcessorServiceImplTest {
         Path traj = base.resolve(TRAJ);
         // processRequiredSeries appelle toRealPath() sur chaque répertoire série → ils doivent exister.
         Path inflowDir = traj.resolve("inflows");
+        Path mingenDir = traj.resolve("mingen");
+        Path reservoirDir = traj.resolve("reservoir_levels");
         Files.createDirectories(inflowDir);
-        Files.createDirectories(traj.resolve("mingen"));
-        Files.createDirectories(traj.resolve("reservoir_levels"));
-        // Un fichier mod pour que hasOnlyRorFile = false et que le check maxpower soit déclenché.
+        Files.createDirectories(mingenDir);
+        Files.createDirectories(reservoirDir);
+        // mingen + reservoir_levels -> maxpower required (absent = exception).
         CreateExcelTestUtil.createMockCsvFile(inflowDir, FILE_NAME_MOD);
+        CreateExcelTestUtil.createMockCsvFile(mingenDir, FILE_NAME_MINGEN);
+        CreateExcelTestUtil.createMockCsvFile(reservoirDir, FILE_NAME_RESERVOIR_LEVELS);
 
         when(trajectoryService.normalizeAndValidateDirectory(any(), any(), any()))
                 .thenReturn(base);
@@ -427,7 +431,7 @@ class HydroFileProcessorServiceImplTest {
         );
 
         assertEquals(HttpStatus.BAD_REQUEST, exception.getHttpStatus());
-        assertEquals("Missing maxpower file in trajectory HYDRO_SERIES", exception.getMessage());
+        assertEquals("Missing maxpower file in Hydro Series trajectory", exception.getMessage());
     }
 
     @Test
@@ -448,9 +452,10 @@ class HydroFileProcessorServiceImplTest {
         Files.createDirectories(mingenDir);
         Path reservoirLevels = missingTrajectoryPath.resolve("reservoir_levels");
         Files.createDirectories(reservoirLevels);
-        // Un fichier mod est nécessaire pour que hasOnlyRorFile = false et que le check maxpower
-        // soit déclenché. Sans lui, filesNameFinal resterait vide et l'erreur serait "Missing files".
+        // mingen + reservoir_levels -> maxpower required but missing
         CreateExcelTestUtil.createMockCsvFile(inflowDir, FILE_NAME_MOD);
+        CreateExcelTestUtil.createMockCsvFile(mingenDir, FILE_NAME_MINGEN);
+        CreateExcelTestUtil.createMockCsvFile(reservoirLevels, FILE_NAME_RESERVOIR_LEVELS);
 
         when(trajectoryService.normalizeAndValidateDirectory(
                 eq(TrajectoryType.HYDRO_SERIES),
@@ -509,7 +514,7 @@ class HydroFileProcessorServiceImplTest {
                 service.processHydroSeriesFile(TrajectoryType.HYDRO_SERIES, TRAJ, HORIZON, 1, AREA_FR, false));
 
         assertEquals(HttpStatus.BAD_REQUEST, exception.getHttpStatus());
-        assertEquals("Missing files in trajectory " + TrajectoryType.HYDRO_SERIES.name(), exception.getMessage());
+        assertEquals("Missing files in Hydro Series trajectory", exception.getMessage());
     }
 
     @Test
@@ -534,7 +539,7 @@ class HydroFileProcessorServiceImplTest {
                 service.processHydroSeriesFile(TrajectoryType.HYDRO_SERIES, TRAJ, HORIZON, 1, AREA_FR, false));
 
         assertEquals(HttpStatus.BAD_REQUEST, exception.getHttpStatus());
-        assertTrue(exception.getMessage().contains("Missing MOD file ({0}) in trajectory Hydro Series trajectory {1}"));
+        assertTrue(exception.getMessage().contains("Missing mod file ({0}) in trajectory Hydro Series trajectory {1}"));
     }
 
     @Test
@@ -559,7 +564,7 @@ class HydroFileProcessorServiceImplTest {
                 service.processHydroSeriesFile(TrajectoryType.HYDRO_SERIES, TRAJ, HORIZON, 1, AREA_FR, false));
 
         assertEquals(HttpStatus.BAD_REQUEST, exception.getHttpStatus());
-        assertTrue(exception.getMessage().contains("Missing MOD file ({0}) in trajectory Hydro Series trajectory {1}"));
+        assertTrue(exception.getMessage().contains("Missing mod file ({0}) in trajectory Hydro Series trajectory {1}"));
     }
 
     // -------------------------------------------------------------------------
@@ -817,7 +822,7 @@ class HydroFileProcessorServiceImplTest {
                 service.validateMaxPowerFile(TrajectoryType.HYDRO_SERIES, dir, TRAJ, HORIZON, AREA_FR, List.of(AREA_FR), List.of()));
 
         assertEquals(HttpStatus.BAD_REQUEST, exception.getHttpStatus());
-        assertEquals("Missing maxpower file in trajectory " + TrajectoryType.HYDRO_SERIES.name(), exception.getMessage());
+        assertEquals("Missing maxpower file in Hydro Series trajectory", exception.getMessage());
     }
 
     @Test
@@ -1119,6 +1124,120 @@ class HydroFileProcessorServiceImplTest {
         // 2 fichiers ROR (FR + BE), aucun maxpower
         assertEquals(2, result.getHydroSeriesEntities().size());
         verify(trajectoryRepository).save(any());
+    }
+
+    @Test
+    void shouldSaveOnlyRorWhenModPresentButMingenAndReservoirLevelsAbsent_specificArea() throws Exception {
+        // Case 1, Scenario 1: inflows has ror + mod, mingen and reservoir_levels dirs are empty.
+        // Expected: only ror is saved
+        Path base = tempDir.resolve("hydro_no_tp_specific");
+        Path traj = base.resolve(TRAJ);
+        Path inflowDir = traj.resolve("inflows");
+        Files.createDirectories(inflowDir);
+        Files.createDirectories(traj.resolve("mingen"));
+        Files.createDirectories(traj.resolve("reservoir_levels"));
+
+        CreateExcelTestUtil.createMockCsvFile(inflowDir, FILE_NAME_ROR);
+        CreateExcelTestUtil.createMockCsvFile(inflowDir, FILE_NAME_MOD);
+
+        when(trajectoryService.normalizeAndValidateDirectory(any(), any(), any())).thenReturn(base);
+        when(trajectoryService.buildDirectoryTrajectory(any(), any(), any(), any(), any(), any()))
+                .thenReturn(new TrajectoryEntity());
+        when(areaRepository.findAllByStudyId(1)).thenReturn(List.of(new AreaEntity() {{
+            setName(AREA_FR);
+        }}));
+
+        TrajectoryEntity result = service.processHydroSeriesFile(TrajectoryType.HYDRO_SERIES, TRAJ, HORIZON, 1, AREA_FR, false);
+
+        assertNotNull(result);
+        assertEquals(1, result.getHydroSeriesEntities().size());
+        assertEquals(FILE_NAME_ROR, result.getHydroSeriesEntities().getFirst().getTsName());
+        verify(trajectoryRepository).save(any());
+    }
+
+    @Test
+    void shouldSaveOnlyRorWhenModPresentButMingenAndReservoirLevelsAbsent_others() throws Exception {
+        // Case 1, Scenario 2: same as above, for Others
+        Path base = tempDir.resolve("hydro_no_tp_others");
+        Path traj = base.resolve(TRAJ);
+        Path inflowDir = traj.resolve("inflows");
+        Files.createDirectories(inflowDir);
+        Files.createDirectories(traj.resolve("mingen"));
+        Files.createDirectories(traj.resolve("reservoir_levels"));
+
+        CreateExcelTestUtil.createMockCsvFile(inflowDir, FILE_NAME_ROR);
+        CreateExcelTestUtil.createMockCsvFile(inflowDir, FILE_NAME_MOD);
+
+        when(trajectoryService.normalizeAndValidateDirectory(any(), any(), any())).thenReturn(base);
+        when(trajectoryService.buildDirectoryTrajectory(any(), any(), any(), any(), any(), any()))
+                .thenReturn(new TrajectoryEntity());
+        when(areaRepository.findAllByStudyId(1)).thenReturn(List.of(new AreaEntity() {{
+            setName(AREA_FR);
+        }}));
+
+        TrajectoryEntity result = service.processHydroSeriesFile(TrajectoryType.HYDRO_SERIES, TRAJ, HORIZON, 1, OTHERS_AREA, false);
+
+        assertNotNull(result);
+        assertEquals(1, result.getHydroSeriesEntities().size());
+        assertEquals(FILE_NAME_ROR, result.getHydroSeriesEntities().getFirst().getTsName());
+        verify(trajectoryRepository).save(any());
+    }
+
+    @Test
+    void shouldThrowMissingFilesWhenOnlyModPresentAndNoRorOrTechnicalFiles_specificArea() throws Exception {
+        // Case 2, Scenario 1: inflows has only mod (no ror), mingen and reservoir_levels are absent
+        // Expected: BusinessException "Missing files in hydro series trajectory".
+        Path base = tempDir.resolve("hydro_no_tp_mod_only_specific");
+        Path traj = base.resolve(TRAJ);
+        Path inflowDir = traj.resolve("inflows");
+        Files.createDirectories(inflowDir);
+        Files.createDirectories(traj.resolve("mingen"));
+        Files.createDirectories(traj.resolve("reservoir_levels"));
+
+        CreateExcelTestUtil.createMockCsvFile(inflowDir, FILE_NAME_MOD);
+
+        when(trajectoryService.normalizeAndValidateDirectory(any(), any(), any())).thenReturn(base);
+        when(trajectoryService.buildDirectoryTrajectory(any(), any(), any(), any(), any(), any()))
+                .thenReturn(new TrajectoryEntity());
+        when(areaRepository.findAllByStudyId(1)).thenReturn(List.of(new AreaEntity() {{
+            setName(AREA_FR);
+        }}));
+
+        BusinessException exception = assertThrows(BusinessException.class, () ->
+                service.processHydroSeriesFile(TrajectoryType.HYDRO_SERIES, TRAJ, HORIZON, 1, AREA_FR, false));
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getHttpStatus());
+        assertTrue(exception.getMessage().contains("Missing files in Hydro Series trajectory"));
+        verify(trajectoryRepository, never()).save(any());
+    }
+
+    @Test
+    void shouldThrowMissingFilesWhenOnlyModPresentAndNoRorOrTechnicalFiles_others() throws Exception {
+        // Case 2, Scenario 2: same for Others. mod present but no ror, no mingen, no reservoir_levels.
+        Path base = tempDir.resolve("hydro_no_tp_mod_only_others");
+        Path traj = base.resolve(TRAJ);
+        Path inflowDir = traj.resolve("inflows");
+        Files.createDirectories(inflowDir);
+        Files.createDirectories(traj.resolve("mingen"));
+        Files.createDirectories(traj.resolve("reservoir_levels"));
+
+        CreateExcelTestUtil.createMockCsvFile(inflowDir, FILE_NAME_MOD);
+        CreateExcelTestUtil.createMockCsvFile(inflowDir, "mod_BE_2029-2030.csv");
+
+        when(trajectoryService.normalizeAndValidateDirectory(any(), any(), any())).thenReturn(base);
+        when(trajectoryService.buildDirectoryTrajectory(any(), any(), any(), any(), any(), any()))
+                .thenReturn(new TrajectoryEntity());
+        when(areaRepository.findAllByStudyId(1)).thenReturn(List.of(
+                new AreaEntity() {{ setName(AREA_FR); }},
+                new AreaEntity() {{ setName("BE"); }}
+        ));
+
+        BusinessException exception = assertThrows(BusinessException.class, () ->
+                service.processHydroSeriesFile(TrajectoryType.HYDRO_SERIES, TRAJ, HORIZON, 1, OTHERS_AREA, false));
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getHttpStatus());
+        assertTrue(exception.getMessage().contains("Missing files in Hydro Series trajectory"));
+        verify(trajectoryRepository, never()).save(any());
     }
 
     // -------------------------------------------------------------------------

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/HydroFileProcessorServiceImplTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/HydroFileProcessorServiceImplTest.java
@@ -953,7 +953,7 @@ class HydroFileProcessorServiceImplTest {
                 service.validateEmptyRequiredColumns(context, new String[]{"col1", "extra"}, true, false, "not_a_number"));
 
         assertEquals(HttpStatus.BAD_REQUEST, exception.getHttpStatus());
-        assertEquals("Column(s) 2 to 6 and 8", exception.getErrorMessageArguments().getFirst());
+        assertEquals("Column(s) 2 to 4, 6 and 8", exception.getErrorMessageArguments().getFirst());
     }
 
     @Test

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/HydroFileProcessorServiceImplTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/HydroFileProcessorServiceImplTest.java
@@ -106,7 +106,7 @@ class HydroFileProcessorServiceImplTest {
         BusinessException exception = assertThrows(BusinessException.class, () ->
                 service.processHydroSeriesFile(TrajectoryType.HYDRO_SERIES, TRAJ, HORIZON, 1, AREA_FR, false)
         );
-        assertTrue(exception.getMessage().contains("Missing maxpower file (maxpower_{0}) in Hydro Series trajectory {0}"));
+        assertTrue(exception.getMessage().contains("Missing maxpower file (maxpower_{1}) in {0} trajectory {1}"));
     }
 
     @Test
@@ -336,7 +336,7 @@ class HydroFileProcessorServiceImplTest {
         );
 
         assertEquals(HttpStatus.BAD_REQUEST, exception.getHttpStatus());
-        assertEquals("Missing folder {0} in Hydro Series trajectory {1}", exception.getMessage());
+        assertEquals("Missing folder {0} in {1} trajectory {2}", exception.getMessage());
 
         verify(trajectoryService).normalizeAndValidateDirectory(
                 TrajectoryType.HYDRO_SERIES,
@@ -417,11 +417,11 @@ class HydroFileProcessorServiceImplTest {
     }
 
     @Test
-    void validateMaxPowerFile_throwsBusinessException_whenFilePathIsNull() {
+    void validateMaxPowerFile_throwsBusinessException_whenFilePathIsNull_psp() {
         BusinessException exception = assertThrows(
                 BusinessException.class,
                 () -> service.validateMaxPowerFile(
-                        TrajectoryType.HYDRO_SERIES,
+                        TrajectoryType.HYDRO_PSP_SERIES,
                         null,
                         "TRAJ",
                         "HORIZON",
@@ -432,7 +432,8 @@ class HydroFileProcessorServiceImplTest {
         );
 
         assertEquals(HttpStatus.BAD_REQUEST, exception.getHttpStatus());
-        assertEquals("Missing maxpower file in Hydro Series trajectory", exception.getMessage());
+        assertEquals("Missing maxpower file in {0} trajectory", exception.getMessage());
+        assertEquals("PSP_Virtual Series", exception.getErrorMessageArguments().get(0));
     }
 
     @Test
@@ -488,7 +489,7 @@ class HydroFileProcessorServiceImplTest {
         );
 
         assertEquals(HttpStatus.BAD_REQUEST, exception.getHttpStatus());
-        assertEquals("Missing maxpower file (maxpower_{0}) in Hydro Series trajectory {0}", exception.getMessage());
+        assertEquals("Missing maxpower file (maxpower_{1}) in {0} trajectory {1}", exception.getMessage());
 
         verify(trajectoryRepository, never()).save(any());
     }
@@ -515,7 +516,7 @@ class HydroFileProcessorServiceImplTest {
                 service.processHydroSeriesFile(TrajectoryType.HYDRO_SERIES, TRAJ, HORIZON, 1, AREA_FR, false));
 
         assertEquals(HttpStatus.BAD_REQUEST, exception.getHttpStatus());
-        assertEquals("Missing files in Hydro Series trajectory", exception.getMessage());
+        assertEquals("Missing files in {0} trajectory", exception.getMessage());
     }
 
     @Test
@@ -540,7 +541,7 @@ class HydroFileProcessorServiceImplTest {
                 service.processHydroSeriesFile(TrajectoryType.HYDRO_SERIES, TRAJ, HORIZON, 1, AREA_FR, false));
 
         assertEquals(HttpStatus.BAD_REQUEST, exception.getHttpStatus());
-        assertTrue(exception.getMessage().contains("Missing mod file ({0}) in Hydro Series trajectory {1}"));
+        assertTrue(exception.getMessage().contains("Missing mod file ({0}) in {1} trajectory {2}"));
     }
 
     @Test
@@ -565,7 +566,7 @@ class HydroFileProcessorServiceImplTest {
                 service.processHydroSeriesFile(TrajectoryType.HYDRO_SERIES, TRAJ, HORIZON, 1, AREA_FR, false));
 
         assertEquals(HttpStatus.BAD_REQUEST, exception.getHttpStatus());
-        assertTrue(exception.getMessage().contains("Missing mod file ({0}) in Hydro Series trajectory {1}"));
+        assertTrue(exception.getMessage().contains("Missing mod file ({0}) in {1} trajectory {2}"));
     }
 
     // -------------------------------------------------------------------------
@@ -823,7 +824,7 @@ class HydroFileProcessorServiceImplTest {
                 service.validateMaxPowerFile(TrajectoryType.HYDRO_SERIES, dir, TRAJ, HORIZON, AREA_FR, List.of(AREA_FR), List.of()));
 
         assertEquals(HttpStatus.BAD_REQUEST, exception.getHttpStatus());
-        assertEquals("Missing maxpower file in Hydro Series trajectory", exception.getMessage());
+        assertEquals("Missing maxpower file in {0} trajectory", exception.getMessage());
     }
 
     @Test
@@ -1094,7 +1095,7 @@ class HydroFileProcessorServiceImplTest {
                 service.processHydroSeriesFile(TrajectoryType.HYDRO_SERIES, TRAJ, HORIZON, 1, OTHERS_AREA, false));
 
         assertEquals(HttpStatus.BAD_REQUEST, exception.getHttpStatus());
-        assertTrue(exception.getMessage().contains("Missing maxpower file (maxpower_{0}) in Hydro Series trajectory {0}"));
+        assertTrue(exception.getMessage().contains("Missing maxpower file (maxpower_{1}) in {0} trajectory {1}"));
     }
 
     @Test
@@ -1208,7 +1209,7 @@ class HydroFileProcessorServiceImplTest {
                 service.processHydroSeriesFile(TrajectoryType.HYDRO_SERIES, TRAJ, HORIZON, 1, AREA_FR, false));
 
         assertEquals(HttpStatus.BAD_REQUEST, exception.getHttpStatus());
-        assertTrue(exception.getMessage().contains("Missing files in Hydro Series trajectory"));
+        assertTrue(exception.getMessage().contains("Missing files in {0} trajectory"));
         verify(trajectoryRepository, never()).save(any());
     }
 
@@ -1237,7 +1238,7 @@ class HydroFileProcessorServiceImplTest {
                 service.processHydroSeriesFile(TrajectoryType.HYDRO_SERIES, TRAJ, HORIZON, 1, OTHERS_AREA, false));
 
         assertEquals(HttpStatus.BAD_REQUEST, exception.getHttpStatus());
-        assertTrue(exception.getMessage().contains("Missing files in Hydro Series trajectory"));
+        assertTrue(exception.getMessage().contains("Missing files in {0} trajectory"));
         verify(trajectoryRepository, never()).save(any());
     }
 

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/HydroFileProcessorServiceImplTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/HydroFileProcessorServiceImplTest.java
@@ -661,7 +661,7 @@ class HydroFileProcessorServiceImplTest {
     }
 
     @Test
-    void processHydroTechnicalParametersFile_throwsWithPspLabelWhenSelectedAreaMissingFromAllocation() throws Exception {
+    void processHydroTechnicalParametersFile_throwsWithPspLabelWhenSelectedAreaMissingFromParameters() throws Exception {
         Path base = tempDir.resolve("hydro_tech_psp_area_mismatch");
         Path traj = base.resolve(TRAJ);
         Files.createDirectories(traj);
@@ -688,7 +688,7 @@ class HydroFileProcessorServiceImplTest {
         assertEquals(HttpStatus.BAD_REQUEST, exception.getHttpStatus());
         String formattedMessage = java.text.MessageFormat.format(exception.getMessage(), exception.getErrorMessageArguments().toArray());
         assertTrue(formattedMessage.contains("Selected area"));
-        assertTrue(formattedMessage.contains("PSP_Virtual hydroAllocation TechnicalParameters"));
+        assertTrue(formattedMessage.contains("PSP_Virtual hydroParameters TechnicalParameters"));
         verify(trajectoryRepository, never()).save(any());
     }
 

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/HydroFileProcessorServiceImplTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/HydroFileProcessorServiceImplTest.java
@@ -30,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -736,8 +737,8 @@ class HydroFileProcessorServiceImplTest {
 
         var entity = ((HydroParametersRowProcessingResult) result).entities().getFirst();
         assertEquals("FR", entity.getNode());
-        assertEquals(2, entity.getInterDailyBreakdown());
-        assertEquals(3, entity.getInterDailyModulation());
+        assertEquals(new BigDecimal("2"), entity.getInterDailyBreakdown());
+        assertEquals(new BigDecimal("3"), entity.getInterDailyModulation());
         assertEquals(Boolean.TRUE, entity.getReservoir());
         assertEquals(Boolean.FALSE, entity.getFollowLoad());
     }

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/HydroGenerationAssemblerServiceImplTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/HydroGenerationAssemblerServiceImplTest.java
@@ -386,7 +386,7 @@ class HydroGenerationAssemblerServiceImplTest {
                 .reservoir(true)
                 .reservoirCapacity(new BigDecimal(5000))
                 .pumpingEfficiency(new BigDecimal("90"))
-                .initializeReservoirDate(new BigDecimal("7"))
+                .initializeReservoirDate(7)
                 .useWater(false)
                 .build();
 
@@ -409,7 +409,7 @@ class HydroGenerationAssemblerServiceImplTest {
         assertEquals(Boolean.TRUE, dto.getProperties().getReservoirManagement());
         assertEquals(new BigDecimal("5000"), dto.getProperties().getReservoirCapacity());
         assertEquals(new BigDecimal("90"), dto.getProperties().getPumpingEfficiency());
-        assertEquals(new BigDecimal("7"), dto.getProperties().getInitializeReservoirDate());
+        assertEquals(7, dto.getProperties().getInitializeReservoirDate());
         assertEquals(Boolean.FALSE, dto.getProperties().getUseWater());
     }
 

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/HydroGenerationAssemblerServiceImplTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/HydroGenerationAssemblerServiceImplTest.java
@@ -60,13 +60,13 @@ class HydroGenerationAssemblerServiceImplTest {
         HydroParametersEntity hp1 = HydroParametersEntity.builder()
                 .node("FR")
                 .followLoad(true)
-                .interDailyBreakdown(1)
+                .interDailyBreakdown(new BigDecimal("1"))
                 .reservoirCapacity(new BigDecimal(1000))
                 .build();
         HydroParametersEntity hp2 = HydroParametersEntity.builder()
                 .node("BE")
                 .followLoad(false)
-                .interDailyBreakdown(2)
+                .interDailyBreakdown(new BigDecimal("2"))
                 .reservoirCapacity(new BigDecimal(2000))
                 .build();
 
@@ -351,12 +351,12 @@ class HydroGenerationAssemblerServiceImplTest {
         HydroParametersEntity hp1 = HydroParametersEntity.builder()
                 .node("FR")
                 .followLoad(true)
-                .interDailyBreakdown(1)
+                .interDailyBreakdown(new BigDecimal("1"))
                 .build();
         HydroParametersEntity hp2 = HydroParametersEntity.builder()
                 .node("FR")
                 .followLoad(false)
-                .interDailyBreakdown(2)
+                .interDailyBreakdown(new BigDecimal("2"))
                 .build();
 
         TrajectoryEntity trajectory = TrajectoryEntity.builder()
@@ -380,13 +380,13 @@ class HydroGenerationAssemblerServiceImplTest {
         HydroParametersEntity hp = HydroParametersEntity.builder()
                 .node("FR")
                 .followLoad(true)
-                .interDailyBreakdown(1)
-                .interDailyModulation(2)
-                .interMonthlyBreakdown(3)
+                .interDailyBreakdown(new BigDecimal("1"))
+                .interDailyModulation(new BigDecimal("2"))
+                .interMonthlyBreakdown(new BigDecimal("3"))
                 .reservoir(true)
                 .reservoirCapacity(new BigDecimal(5000))
-                .pumpingEfficiency(90)
-                .initializeReservoirDate(7)
+                .pumpingEfficiency(new BigDecimal("90"))
+                .initializeReservoirDate(new BigDecimal("7"))
                 .useWater(false)
                 .build();
 
@@ -403,13 +403,13 @@ class HydroGenerationAssemblerServiceImplTest {
 
         HydroGenerationDTO dto = result.get("FR").get(0);
         assertEquals(Boolean.TRUE, dto.getProperties().getFollowLoadModulation());
-        assertEquals(1, dto.getProperties().getInterDailyBreakdown());
-        assertEquals(2, dto.getProperties().getInterDailyModulation());
-        assertEquals(3, dto.getProperties().getInterMonthlyBreakdown());
+        assertEquals(new BigDecimal("1"), dto.getProperties().getInterDailyBreakdown());
+        assertEquals(new BigDecimal("2"), dto.getProperties().getInterDailyModulation());
+        assertEquals(new BigDecimal("3"), dto.getProperties().getInterMonthlyBreakdown());
         assertEquals(Boolean.TRUE, dto.getProperties().getReservoirManagement());
         assertEquals(5000, dto.getProperties().getReservoirCapacity());
-        assertEquals(90, dto.getProperties().getPumpingEfficiency());
-        assertEquals(7, dto.getProperties().getInitializeReservoirDate());
+        assertEquals(new BigDecimal("90"), dto.getProperties().getPumpingEfficiency());
+        assertEquals(new BigDecimal("7"), dto.getProperties().getInitializeReservoirDate());
         assertEquals(Boolean.FALSE, dto.getProperties().getUseWater());
     }
 

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/HydroGenerationAssemblerServiceImplTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/HydroGenerationAssemblerServiceImplTest.java
@@ -89,12 +89,12 @@ class HydroGenerationAssemblerServiceImplTest {
         List<HydroGenerationDTO> frProps = result.get("FR");
         assertEquals(1, frProps.size());
         assertEquals(Boolean.TRUE, frProps.getFirst().getProperties().getFollowLoadModulation());
-        assertEquals(1000, frProps.getFirst().getProperties().getReservoirCapacity());
+        assertEquals(new BigDecimal("1000"), frProps.getFirst().getProperties().getReservoirCapacity());
 
         List<HydroGenerationDTO> beProps = result.get("BE");
         assertEquals(1, beProps.size());
         assertEquals(Boolean.FALSE, beProps.getFirst().getProperties().getFollowLoadModulation());
-        assertEquals(2000, beProps.getFirst().getProperties().getReservoirCapacity());
+        assertEquals(new BigDecimal("2000"), beProps.getFirst().getProperties().getReservoirCapacity());
     }
 
     @Test
@@ -407,7 +407,7 @@ class HydroGenerationAssemblerServiceImplTest {
         assertEquals(new BigDecimal("2"), dto.getProperties().getInterDailyModulation());
         assertEquals(new BigDecimal("3"), dto.getProperties().getInterMonthlyBreakdown());
         assertEquals(Boolean.TRUE, dto.getProperties().getReservoirManagement());
-        assertEquals(5000, dto.getProperties().getReservoirCapacity());
+        assertEquals(new BigDecimal("5000"), dto.getProperties().getReservoirCapacity());
         assertEquals(new BigDecimal("90"), dto.getProperties().getPumpingEfficiency());
         assertEquals(new BigDecimal("7"), dto.getProperties().getInitializeReservoirDate());
         assertEquals(Boolean.FALSE, dto.getProperties().getUseWater());
@@ -862,7 +862,7 @@ class HydroGenerationAssemblerServiceImplTest {
         Map<String, List<HydroGenerationDTO>> result = service.assembleHydroProperties(studyEntity);
 
         assertEquals(1, result.size());
-        assertEquals(3000, result.get("FR").get(0).getProperties().getReservoirCapacity());
+        assertEquals(new BigDecimal("3000"), result.get("FR").get(0).getProperties().getReservoirCapacity());
     }
 
     @Test

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/HydroToJsonServiceTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/HydroToJsonServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -68,7 +69,7 @@ class HydroToJsonServiceTest {
         String[] series = {"file1.arrow", "file2.arrow"};
         Map<String, Double> allocation = Map.of("BE", 0.5, "DE", 0.5);
         HydroPropertiesGenerationDTO properties = HydroPropertiesGenerationDTO.builder().followLoadModulation(true)
-                .interDailyBreakdown(1).build();
+                .interDailyBreakdown(new BigDecimal("1")).build();
         HydroGenerationDTO dto = HydroGenerationDTO.builder()
                 .properties(properties)
                 .series(series)
@@ -113,11 +114,11 @@ class HydroToJsonServiceTest {
     void buildHydroDataMap_multipleDtosAreAllReturned() {
         String[] series = {"file.arrow"};
         Map<String, Double> allocation = Map.of("BE", 1.0);
-        HydroPropertiesGenerationDTO properties1 = HydroPropertiesGenerationDTO.builder().interDailyBreakdown(1).build();
+        HydroPropertiesGenerationDTO properties1 = HydroPropertiesGenerationDTO.builder().interDailyBreakdown(new BigDecimal("1")).build();
         HydroGenerationDTO dto1 = HydroGenerationDTO.builder().properties(properties1).series(series).allocation(allocation).build();
-        HydroPropertiesGenerationDTO properties2 = HydroPropertiesGenerationDTO.builder().interDailyModulation(2).build();
+        HydroPropertiesGenerationDTO properties2 = HydroPropertiesGenerationDTO.builder().interDailyModulation(new BigDecimal("2")).build();
         HydroGenerationDTO dto2 = HydroGenerationDTO.builder().properties(properties2).series(series).allocation(allocation).build();
-        HydroPropertiesGenerationDTO properties3 = HydroPropertiesGenerationDTO.builder().interDailyBreakdown(3).build();
+        HydroPropertiesGenerationDTO properties3 = HydroPropertiesGenerationDTO.builder().interDailyBreakdown(new BigDecimal("3")).build();
         HydroGenerationDTO dto3 = HydroGenerationDTO.builder().properties(properties3).series(series).allocation(allocation).build();
         List<HydroGenerationDTO> dtos = List.of(dto1, dto2, dto3);
         Map<String, List<HydroGenerationDTO>> hydroProps = Map.of("FR", dtos);
@@ -126,7 +127,7 @@ class HydroToJsonServiceTest {
 
         @SuppressWarnings("unchecked")
         HydroPropertiesGenerationDTO returnedDtos = (HydroPropertiesGenerationDTO) result.get("properties");
-        assertEquals(1, returnedDtos.getInterDailyBreakdown());
+        assertEquals(new BigDecimal("1"), returnedDtos.getInterDailyBreakdown());
         assertArrayEquals(series, (String[]) result.get("series"));
         assertEquals(allocation, result.get("allocation"));
     }
@@ -143,9 +144,9 @@ class HydroToJsonServiceTest {
 
     @Test
     void buildHydroDataMap_multipleAreasInMapReturnsOnlyRequestedArea() {
-        HydroPropertiesGenerationDTO properties1 = HydroPropertiesGenerationDTO.builder().interDailyBreakdown(1).build();
+        HydroPropertiesGenerationDTO properties1 = HydroPropertiesGenerationDTO.builder().interDailyBreakdown(new BigDecimal("1")).build();
         HydroGenerationDTO dtoFR = HydroGenerationDTO.builder().properties(properties1).build();
-        HydroPropertiesGenerationDTO properties2 = HydroPropertiesGenerationDTO.builder().interDailyBreakdown(2).build();
+        HydroPropertiesGenerationDTO properties2 = HydroPropertiesGenerationDTO.builder().interDailyBreakdown(new BigDecimal("2")).build();
         HydroGenerationDTO dtoBE = HydroGenerationDTO.builder().properties(properties2).build();
         Map<String, List<HydroGenerationDTO>> hydroProps = Map.of(
                 "FR", List.of(dtoFR),


### PR DESCRIPTION
- [ANT-5063:](https://gopro-tickets.rte-france.com/browse/ANT-5063)
fix1: only ror is saved when mingen/reservoir are missing 
fix2: missing ror with no mingen/reservoir_levels now throws "Missing files" instead of importing                                                                                                  
fix3: each area pulls its own files (an area with existing files used to mask another area with missing required files)      

- General fixes:                                                                                                  
fix4: optzimied O(n^2) io scan in consistency check                 

- [ANT-5224:](https://gopro-tickets.rte-france.com/browse/ANT-5224)
fix5: remove area validation for hydro allocation type

- [ANT-5229](https://gopro-tickets.rte-france.com/browse/ANT-5229)
fix6: change hydro integer values to decimal

- [ANT-5109](https://gopro-tickets.rte-france.com/browse/ANT-5109)
fix7: make lookups for hydro case insensitive