### PR TITLE
feat: ANT-5285 - add support for nuclear availability gen (EPR, LT, SMR)

### DIFF
--- a/src/main/java/com/rte_france/antares/datamanager_back/configuration/AntaresDataManagerProperties.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/configuration/AntaresDataManagerProperties.java
@@ -127,6 +127,9 @@ public class AntaresDataManagerProperties {
     @Value("${antares.datamanager.nuclear.talon.ts.output.directory}")
     public String nuclearTalonTsOutputDirectory;
 
+    @Value("${antares.datamanager.nuclear.availability.ts.output.directory}")
+    public String nuclearAvailabilityTsOutputDirectory;
+
     @Value("${antares.datamanager.adequacy.directory}")
     public String adequacyDirectory;
 }

--- a/src/main/java/com/rte_france/antares/datamanager_back/dto/AreasGenerationContextDTO.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/dto/AreasGenerationContextDTO.java
@@ -17,4 +17,6 @@ public class AreasGenerationContextDTO {
     private Map<String, Map<String, ResClusterGenerationDto>> resProps;
     private Map<String, HydroAreaGenerationDTO> hydroProps;
     private Map<String, String> adequacyModeByArea;
+    private Map<String, String> nuclearSeriesByClusterKey;
+    private Map<String, NuclearSMRMixageDTO> nuclearSmrMixageByClusterKey;
 }

--- a/src/main/java/com/rte_france/antares/datamanager_back/dto/NuclearSMRMixageDTO.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/dto/NuclearSMRMixageDTO.java
@@ -1,0 +1,3 @@
+package com.rte_france.antares.datamanager_back.dto;
+
+public record NuclearSMRMixageDTO(int unitCount, String seed) {}

--- a/src/main/java/com/rte_france/antares/datamanager_back/repository/ClusterDesignationRepository.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/repository/ClusterDesignationRepository.java
@@ -5,7 +5,10 @@ import com.rte_france.antares.datamanager_back.repository.model.ClusterDesignati
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ClusterDesignationRepository extends JpaRepository<ClusterDesignationEntity, ClusterDesignationKey> {
+    List<ClusterDesignationEntity> findByCluster_TypeCluster(String typeCluster);
 }
 

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/nuclear/NuclearAvailabilityAssemblerService.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/nuclear/NuclearAvailabilityAssemblerService.java
@@ -1,0 +1,23 @@
+package com.rte_france.antares.datamanager_back.service.nuclear;
+
+import com.rte_france.antares.datamanager_back.dto.ThermalClusterGenerationDto;
+import com.rte_france.antares.datamanager_back.repository.model.StudyEntity;
+import com.rte_france.antares.datamanager_back.service.thermal.impl.ThermalPropertiesAssemblerService.AreaClusterRefKey;
+
+import java.util.Map;
+
+public interface NuclearAvailabilityAssemblerService {
+
+    /**
+     * Computes the nuclear availability series (LT, EPR, SMR) for whichever of the three
+     * trajectories are linked to the study. LT and EPR clusters get a ready Arrow file and SMR clusters get
+     * a shared Arrow file and the metadata (active unit count, seed) needed for the
+     * python generator to perform the seeded draw itself. 
+     *  
+     * @return an empty safe result when none
+     * of the three trajectories are linked.
+     */
+    NuclearAvailabilityAssemblyResult assembleAvailability(
+            StudyEntity study,
+            Map<AreaClusterRefKey, ThermalClusterGenerationDto> thermalClusterProps);
+}

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/nuclear/NuclearAvailabilityAssemblyResult.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/nuclear/NuclearAvailabilityAssemblyResult.java
@@ -1,0 +1,15 @@
+package com.rte_france.antares.datamanager_back.service.nuclear;
+
+import com.rte_france.antares.datamanager_back.dto.NuclearSMRMixageDTO;
+import com.rte_france.antares.datamanager_back.service.thermal.impl.ThermalPropertiesAssemblerService.AreaClusterRefKey;
+
+import java.util.Map;
+
+/**
+ * Result of nuclear availability assembly, keyed by the same {@link AreaClusterRefKey} used
+ * during thermal cluster assembly. (FR node and y_nuc_modulation node independently project these into their own json key formats)
+ */
+public record NuclearAvailabilityAssemblyResult(
+        Map<AreaClusterRefKey, String> seriesByCluster,
+        Map<AreaClusterRefKey, NuclearSMRMixageDTO> smrMixageByCluster
+) {}

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/nuclear/NuclearClusterNames.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/nuclear/NuclearClusterNames.java
@@ -6,6 +6,8 @@ public final class NuclearClusterNames {
 
     private static final String NUCLEAR_MARKER = "nuclear";
     private static final String PEAK_MARKER = "peak";
+    private static final String EPR_MARKER = "epr";
+    private static final String SMR_MARKER = "smr";
 
     private NuclearClusterNames() {
     }
@@ -20,5 +22,13 @@ public final class NuclearClusterNames {
 
     public static boolean isPeak(String clusterName) {
         return normalize(clusterName).contains(PEAK_MARKER);
+    }
+
+    public static boolean isEpr(String clusterName) {
+        return normalize(clusterName).contains(EPR_MARKER);
+    }
+
+    public static boolean isSmr(String clusterName) {
+        return normalize(clusterName).contains(SMR_MARKER);
     }
 }

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/nuclear/NuclearClusterNames.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/nuclear/NuclearClusterNames.java
@@ -8,6 +8,8 @@ public final class NuclearClusterNames {
     private static final String PEAK_MARKER = "peak";
     private static final String EPR_MARKER = "epr";
     private static final String SMR_MARKER = "smr";
+    private static final String N4_MARKER = "n4";
+    private static final String P4_MARKER = "p4";
 
     private NuclearClusterNames() {
     }
@@ -30,5 +32,13 @@ public final class NuclearClusterNames {
 
     public static boolean isSmr(String clusterName) {
         return normalize(clusterName).contains(SMR_MARKER);
+    }
+
+    public static boolean isN4(String clusterName) {
+        return normalize(clusterName).contains(N4_MARKER);
+    }
+
+    public static boolean isP4(String clusterName) {
+        return normalize(clusterName).contains(P4_MARKER);
     }
 }

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/nuclear/NuclearFilePrefixes.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/nuclear/NuclearFilePrefixes.java
@@ -3,6 +3,8 @@ package com.rte_france.antares.datamanager_back.service.nuclear;
 public final class NuclearFilePrefixes {
 
     public static final String TALON_FILE_PREFIX = "TALON_NUC_";
+    public static final String EPR_FILE_PREFIX = "TS_EPR_";
+    public static final String SMR_FILE_PREFIX = "TS_SMR_";
 
     private NuclearFilePrefixes() { }
 }

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/nuclear/impl/NuclearAvailabilityAssemblerServiceImpl.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/nuclear/impl/NuclearAvailabilityAssemblerServiceImpl.java
@@ -1,0 +1,309 @@
+package com.rte_france.antares.datamanager_back.service.nuclear.impl;
+
+import com.rte_france.antares.datamanager_back.configuration.AntaresDataManagerProperties;
+import com.rte_france.antares.datamanager_back.dto.NuclearSMRMixageDTO;
+import com.rte_france.antares.datamanager_back.dto.ThermalClusterGenerationDto;
+import com.rte_france.antares.datamanager_back.dto.TrajectoryType;
+import com.rte_france.antares.datamanager_back.exception.BusinessException;
+import com.rte_france.antares.datamanager_back.exception.TechnicalException;
+import com.rte_france.antares.datamanager_back.repository.ClusterDesignationRepository;
+import com.rte_france.antares.datamanager_back.repository.model.StudyEntity;
+import com.rte_france.antares.datamanager_back.repository.model.TrajectoryEntity;
+import com.rte_france.antares.datamanager_back.service.common.impl.NasFileService;
+import com.rte_france.antares.datamanager_back.service.nuclear.NuclearAvailabilityAssemblerService;
+import com.rte_france.antares.datamanager_back.service.nuclear.NuclearAvailabilityAssemblyResult;
+import com.rte_france.antares.datamanager_back.service.nuclear.NuclearClusterNames;
+import com.rte_france.antares.datamanager_back.service.nuclear.NuclearFilePrefixes;
+import com.rte_france.antares.datamanager_back.service.thermal.impl.ThermalPropertiesAssemblerService.AreaClusterRefKey;
+import com.rte_france.antares.datamanager_back.util.PathSecurityUtil;
+import com.rte_france.antares.datamanager_back.util.timeseries_manager.TimeSeriesMatrix;
+import com.rte_france.antares.datamanager_back.util.timeseries_manager.TimeSeriesMatrixColumn;
+import com.rte_france.antares.datamanager_back.util.timeseries_manager.TimeSeriesReader;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NuclearAvailabilityAssemblerServiceImpl implements NuclearAvailabilityAssemblerService {
+
+    private static final String FR_AREA = "fr";
+    private static final String LT_SIMU_FILE_PREFIX = "Simu_";
+    private static final String XLSX_SUFFIX = ".xlsx";
+    private static final String SMR_EXCLUDED_COLUMN = "TS_EPR_clim";
+    private static final String SEED_SUFFIX = "seed-tsgen-thermal";
+    private static final String CP0_CP1_CP2_DESIGNATION = "cp0_cp1_cp2";
+    private static final int HOURS_PER_DAY = 24;
+
+    private final NasFileService nasFileService;
+    private final TimeSeriesReader timeSeriesReader;
+    private final AntaresDataManagerProperties properties;
+    private final PathSecurityUtil pathSecurityUtil;
+    private final ClusterDesignationRepository clusterDesignationRepository;
+
+    @Override
+    public NuclearAvailabilityAssemblyResult assembleAvailability(StudyEntity study,
+            Map<AreaClusterRefKey, ThermalClusterGenerationDto> thermalClusterProps) {
+
+        Set<TrajectoryEntity> trajectories = study.getTrajectories();
+        Optional<TrajectoryEntity> eprTrajectory = findFirstByType(trajectories, TrajectoryType.NUCLEAR_FR_TS_ERP);
+        Optional<TrajectoryEntity> ltTrajectory = findFirstByType(trajectories, TrajectoryType.NUCLEAR_FR_TS_LONG_TERM);
+        Optional<TrajectoryEntity> smrTrajectory = findFirstByType(trajectories, TrajectoryType.NUCLEAR_FR_TS_SMR);
+
+        String horizonYear = extractHorizonYear(study.getHorizon());
+        Map<AreaClusterRefKey, String> seriesByCluster = new LinkedHashMap<>();
+        Map<AreaClusterRefKey, NuclearSMRMixageDTO> smrMixageByCluster = new LinkedHashMap<>();
+
+        ltTrajectory.ifPresent(traj -> {
+            String arrowFile = assembleLongTermSeries(traj, study.getHorizon());
+            collectMatchingClusters(thermalClusterProps, NuclearAvailabilityAssemblerServiceImpl::isLongTermCluster)
+                    .forEach(key -> seriesByCluster.put(key, arrowFile));
+        });
+
+        eprTrajectory.ifPresent(traj -> {
+            String arrowFile = assembleEprSeries(traj, horizonYear);
+            collectMatchingClusters(thermalClusterProps, NuclearClusterNames::isEpr)
+                    .forEach(key -> seriesByCluster.put(key, arrowFile));
+        });
+
+        smrTrajectory.ifPresent(traj -> assembleSmrAvailability(traj, horizonYear, thermalClusterProps, seriesByCluster, smrMixageByCluster));
+
+        return new NuclearAvailabilityAssemblyResult(seriesByCluster, smrMixageByCluster);
+    }
+
+    private static Optional<TrajectoryEntity> findFirstByType(Set<TrajectoryEntity> trajectories, TrajectoryType type) {
+        return trajectories.stream()
+                .filter(t -> type.name().equals(t.getType()))
+                .findFirst();
+    }
+
+    private static boolean isLongTermCluster(String clusterName) {
+        return NuclearClusterNames.isNuclear(clusterName)
+                && !NuclearClusterNames.isPeak(clusterName)
+                && !NuclearClusterNames.isEpr(clusterName)
+                && !NuclearClusterNames.isSmr(clusterName);
+    }
+
+    private static List<AreaClusterRefKey> collectMatchingClusters(Map<AreaClusterRefKey, ThermalClusterGenerationDto> thermalClusterProps,
+            Predicate<String> clusterNamePredicate) {
+        return thermalClusterProps.keySet().stream()
+                .filter(key -> FR_AREA.equalsIgnoreCase(key.area()) && clusterNamePredicate.test(key.thermalClusterRef().getName()))
+                .toList();
+    }
+
+    private String assembleLongTermSeries(TrajectoryEntity ltTrajectory, String horizon) {
+        Path relativePath = Path.of(properties.getNuclearLtDirectory())
+                .resolve(ltTrajectory.getFileName())
+                .resolve(LT_SIMU_FILE_PREFIX + horizon + XLSX_SUFFIX);
+        Path ltPath = resolveValidatedNasPath(relativePath, "Invalid nuclear LT path: {0}");
+
+        try {
+            Set<String> whitelist = loadCp0Cp1Cp2Whitelist();
+            List<String> sheetNames = timeSeriesReader.listSheetNames(ltPath);
+
+            List<TimeSeriesMatrixColumn> onglets = new ArrayList<>(sheetNames.size());
+            for (String sheetName : sheetNames) {
+                TimeSeriesMatrix selected = timeSeriesReader.readSelectedColumnsFromXlsx(ltPath, sheetName, whitelist);
+                double[] hourly = expandDailyToHourly(sumColumnsRowWise(selected));
+                onglets.add(new TimeSeriesMatrixColumn(sheetName, hourly));
+            }
+
+            TimeSeriesMatrix combined = new TimeSeriesMatrix(onglets);
+            byte[] bytes = nasFileService.getWriter().writeToByteArray(combined);
+            return nasFileService.saveMatrixBytesToNas(bytes, ltTrajectory.getFileName() + "_lt", properties.getNuclearAvailabilityTsOutputDirectory());
+        } catch (IOException e) {
+            throw TechnicalException.builder()
+                    .errorMessageArguments(List.of(ltTrajectory.getFileName()))
+                    .message("Failed to assemble nuclear LT availability series for trajectory: {0}")
+                    .cause(e)
+                    .build();
+        }
+    }
+
+    private Set<String> loadCp0Cp1Cp2Whitelist() {
+        return clusterDesignationRepository.findByCluster_TypeCluster(CP0_CP1_CP2_DESIGNATION)
+                .stream()
+                .map(designation -> designation.getId().getNomCluster())
+                .collect(Collectors.toSet());
+    }
+
+    private static double[] sumColumnsRowWise(TimeSeriesMatrix matrix) {
+        int rowCount = matrix.getRowCount();
+        double[] sums = new double[rowCount];
+        for (TimeSeriesMatrixColumn column : matrix.columns()) {
+            double[] values = column.values();
+            for (int i = 0; i < rowCount; i++) {
+                sums[i] += values[i];
+            }
+        }
+        return sums;
+    }
+
+    private static double[] expandDailyToHourly(double[] dailyValues) {
+        double[] hourly = new double[dailyValues.length * HOURS_PER_DAY];
+        for (int day = 0; day < dailyValues.length; day++) {
+            Arrays.fill(hourly, day * HOURS_PER_DAY, (day + 1) * HOURS_PER_DAY, dailyValues[day]);
+        }
+        return hourly;
+    }
+
+    private String assembleEprSeries(TrajectoryEntity eprTrajectory, String horizonYear) {
+        try {
+            Path relativePath = resolvePrefixedRelativePath(properties.getNuclearEprDirectory(),
+                    NuclearFilePrefixes.EPR_FILE_PREFIX, eprTrajectory.getFileName());
+            Path eprPath = resolveValidatedNasPath(relativePath, "Invalid nuclear EPR path: {0}");
+            return nasFileService.readAndSaveMatrixToNas(eprPath, properties.getNuclearAvailabilityTsOutputDirectory(), horizonYear, true);
+        } catch (IOException e) {
+            throw TechnicalException.builder()
+                    .errorMessageArguments(List.of(eprTrajectory.getFileName()))
+                    .message("Failed to assemble nuclear EPR availability series for trajectory: {0}")
+                    .cause(e)
+                    .build();
+        }
+    }
+
+    /**
+     * SMR availability is only prepared here, not fianlized: the raw column pool (without the excluded
+     * "TS_EPR_clim" column) is converted to a single shared Arrow file, and each matched cluster gets
+     * the active unit count and a composed seed string. The seeded "mixage des
+     * chroniques" that combines pool columns per active unit is left for the python
+     * generator
+     */
+    private void assembleSmrAvailability(TrajectoryEntity smrTrajectory, String horizonYear,
+            Map<AreaClusterRefKey, ThermalClusterGenerationDto> thermalClusterProps,
+            Map<AreaClusterRefKey, String> seriesByCluster,
+            Map<AreaClusterRefKey, NuclearSMRMixageDTO> smrMixageByCluster) {
+        List<AreaClusterRefKey> matchedClusters = collectMatchingClusters(thermalClusterProps, NuclearClusterNames::isSmr);
+        if (matchedClusters.isEmpty()) {
+            return;
+        }
+
+        Map<AreaClusterRefKey, Integer> unitCountByCluster = requireUnitCounts(matchedClusters, thermalClusterProps);
+
+        List<TimeSeriesMatrixColumn> filteredColumns = readFilteredSmrPool(smrTrajectory, horizonYear);
+        if (filteredColumns.isEmpty()) {
+            return;
+        }
+
+        String arrowFile = writeSharedSmrPool(smrTrajectory, filteredColumns);
+        for (AreaClusterRefKey key : matchedClusters) {
+            seriesByCluster.put(key, arrowFile);
+            smrMixageByCluster.put(key, new NuclearSMRMixageDTO(unitCountByCluster.get(key), buildSeed(FR_AREA, key.thermalClusterRef().getName())));
+        }
+    }
+
+    private static Map<AreaClusterRefKey, Integer> requireUnitCounts(List<AreaClusterRefKey> matchedClusters,
+            Map<AreaClusterRefKey, ThermalClusterGenerationDto> thermalClusterProps) {
+        Map<AreaClusterRefKey, Integer> unitCountByCluster = new LinkedHashMap<>();
+        for (AreaClusterRefKey key : matchedClusters) {
+            unitCountByCluster.put(key, requireUnitCount(thermalClusterProps.get(key), key.thermalClusterRef().getName()));
+        }
+        return unitCountByCluster;
+    }
+
+    private List<TimeSeriesMatrixColumn> readFilteredSmrPool(TrajectoryEntity smrTrajectory, String horizonYear) {
+        try {
+            Path relativePath = resolvePrefixedRelativePath(properties.getNuclearSmrDirectory(),
+                    NuclearFilePrefixes.SMR_FILE_PREFIX, smrTrajectory.getFileName());
+            Path smrPath = resolveValidatedNasPath(relativePath, "Invalid nuclear SMR path: {0}");
+
+            TimeSeriesMatrix pool = nasFileService.readMatrix(smrPath, horizonYear, true,
+                    TrajectoryType.NUCLEAR_FR_TS_SMR.name(), "SMR");
+            return pool.columns().stream()
+                    .filter(column -> !SMR_EXCLUDED_COLUMN.equalsIgnoreCase(column.name()))
+                    .toList();
+        } catch (IOException e) {
+            throw TechnicalException.builder()
+                    .errorMessageArguments(List.of(smrTrajectory.getFileName()))
+                    .message("Failed to read nuclear SMR availability pool for trajectory: {0}")
+                    .cause(e)
+                    .build();
+        }
+    }
+
+    private String writeSharedSmrPool(TrajectoryEntity smrTrajectory, List<TimeSeriesMatrixColumn> filteredColumns) {
+        try {
+            byte[] bytes = nasFileService.getWriter().writeToByteArray(new TimeSeriesMatrix(filteredColumns));
+            return nasFileService.saveMatrixBytesToNas(bytes,
+                    smrTrajectory.getFileName() + "_smr", properties.getNuclearAvailabilityTsOutputDirectory());
+        } catch (IOException e) {
+            throw TechnicalException.builder()
+                    .errorMessageArguments(List.of(smrTrajectory.getFileName()))
+                    .message("Failed to write nuclear SMR availability pool for trajectory: {0}")
+                    .cause(e)
+                    .build();
+        }
+    }
+
+    private static int requireUnitCount(ThermalClusterGenerationDto dto, String clusterName) {
+        Integer unitCount = dto.getUnitCount();
+        if (unitCount == null || unitCount <= 0) {
+            throw BusinessException.builder()
+                    .message("Nuclear SMR cluster {0} has no valid unit count for availability mixage")
+                    .errorMessageArguments(List.of(clusterName))
+                    .httpStatus(HttpStatus.BAD_REQUEST)
+                    .build();
+        }
+        return unitCount;
+    }
+
+    private static String buildSeed(String zone, String clusterName) {
+        return zone + clusterName + SEED_SUFFIX;
+    }
+
+    private Path resolvePrefixedRelativePath(String directoryProperty, String prefix, String storedFileName) throws IOException {
+        Path directory = Path.of(directoryProperty);
+        for (String candidatePrefix : List.of(prefix, prefix.toLowerCase(Locale.ROOT))) {
+            Path candidate = directory.resolve(buildPrefixedFileName(candidatePrefix, storedFileName));
+            if (Files.exists(resolveNasPath(candidate))) {
+                return candidate;
+            }
+        }
+        throw new IOException("Nuclear file not found for: " + storedFileName);
+    }
+
+    private String buildPrefixedFileName(String prefix, String storedFileName) {
+        String prefixed = prefix + storedFileName;
+        return prefixed.toLowerCase(Locale.ROOT).endsWith(XLSX_SUFFIX) ? prefixed : prefixed + XLSX_SUFFIX;
+    }
+
+    private String extractHorizonYear(String horizon) {
+        return horizon != null && horizon.contains("-") ? horizon.split("-")[1] : horizon;
+    }
+
+    private Path resolveNasPath(Path relativePath) {
+        return Path.of(properties.getNasDirectory())
+                .resolve(properties.getTrajectoryFilePath())
+                .resolve(relativePath)
+                .normalize();
+    }
+
+    private Path resolveValidatedNasPath(Path relativePath, String invalidPathMessage) {
+        try {
+            pathSecurityUtil.validatePathFromBaseDir(relativePath.toString(), AntaresDataManagerProperties::getTrajectoryFilePath);
+        } catch (IOException e) {
+            throw TechnicalException.builder()
+                    .errorMessageArguments(List.of(relativePath.toString()))
+                    .message(invalidPathMessage)
+                    .cause(e)
+                    .build();
+        }
+        return resolveNasPath(relativePath);
+    }
+}

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/nuclear/impl/NuclearAvailabilityAssemblerServiceImpl.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/nuclear/impl/NuclearAvailabilityAssemblerServiceImpl.java
@@ -48,7 +48,21 @@ public class NuclearAvailabilityAssemblerServiceImpl implements NuclearAvailabil
     private static final String XLSX_SUFFIX = ".xlsx";
     private static final String SEED_SUFFIX = "seed-tsgen-thermal";
     private static final String CP0_CP1_CP2_DESIGNATION = "cp0_cp1_cp2";
+    private static final String N4_DESIGNATION = "n4";
     private static final int HOURS_PER_DAY = 24;
+
+    /**
+     * Explicit, not name-derived: which referential designation backs which LT cluster names.
+     * N4 and P4 cluster names share the "n4" designation (p4 is folded into n4
+     * in the referential).
+     */
+    private static final List<LtDesignationGroup> LT_DESIGNATION_GROUPS = List.of(
+            new LtDesignationGroup(N4_DESIGNATION, NuclearAvailabilityAssemblerServiceImpl::isN4OrP4Cluster),
+            new LtDesignationGroup(CP0_CP1_CP2_DESIGNATION, NuclearAvailabilityAssemblerServiceImpl::isDefaultLongTermCluster)
+    );
+
+    private record LtDesignationGroup(String designation, Predicate<String> clusterNameMatcher) {
+    }
 
     private final NasFileService nasFileService;
     private final TimeSeriesReader timeSeriesReader;
@@ -69,11 +83,13 @@ public class NuclearAvailabilityAssemblerServiceImpl implements NuclearAvailabil
         Map<AreaClusterRefKey, String> seriesByCluster = new LinkedHashMap<>();
         Map<AreaClusterRefKey, NuclearSMRMixageDTO> smrMixageByCluster = new LinkedHashMap<>();
 
-        ltTrajectory.ifPresent(traj -> {
-            String arrowFile = assembleLongTermSeries(traj, study.getHorizon());
-            collectMatchingClusters(thermalClusterProps, NuclearAvailabilityAssemblerServiceImpl::isLongTermCluster)
-                    .forEach(key -> seriesByCluster.put(key, arrowFile));
-        });
+        ltTrajectory.ifPresent(traj -> LT_DESIGNATION_GROUPS.forEach(group -> {
+            List<AreaClusterRefKey> matched = collectMatchingClusters(thermalClusterProps, group.clusterNameMatcher());
+            if (!matched.isEmpty()) {
+                String arrowFile = assembleLongTermSeries(traj, study.getHorizon(), group.designation());
+                matched.forEach(key -> seriesByCluster.put(key, arrowFile));
+            }
+        }));
 
         eprTrajectory.ifPresent(traj -> {
             String arrowFile = assembleEprSeries(traj, horizonYear);
@@ -92,11 +108,19 @@ public class NuclearAvailabilityAssemblerServiceImpl implements NuclearAvailabil
                 .findFirst();
     }
 
-    private static boolean isLongTermCluster(String clusterName) {
+    private static boolean isN4OrP4Cluster(String clusterName) {
+        return NuclearClusterNames.isNuclear(clusterName)
+                && !NuclearClusterNames.isPeak(clusterName)
+                && (NuclearClusterNames.isN4(clusterName) || NuclearClusterNames.isP4(clusterName));
+    }
+
+    private static boolean isDefaultLongTermCluster(String clusterName) {
         return NuclearClusterNames.isNuclear(clusterName)
                 && !NuclearClusterNames.isPeak(clusterName)
                 && !NuclearClusterNames.isEpr(clusterName)
-                && !NuclearClusterNames.isSmr(clusterName);
+                && !NuclearClusterNames.isSmr(clusterName)
+                && !NuclearClusterNames.isN4(clusterName)
+                && !NuclearClusterNames.isP4(clusterName);
     }
 
     private static List<AreaClusterRefKey> collectMatchingClusters(Map<AreaClusterRefKey, ThermalClusterGenerationDto> thermalClusterProps,
@@ -106,14 +130,14 @@ public class NuclearAvailabilityAssemblerServiceImpl implements NuclearAvailabil
                 .toList();
     }
 
-    private String assembleLongTermSeries(TrajectoryEntity ltTrajectory, String horizon) {
+    private String assembleLongTermSeries(TrajectoryEntity ltTrajectory, String horizon, String designation) {
         Path relativePath = Path.of(properties.getNuclearLtDirectory())
                 .resolve(ltTrajectory.getFileName())
                 .resolve(LT_SIMU_FILE_PREFIX + horizon + XLSX_SUFFIX);
         Path ltPath = resolveValidatedNasPath(relativePath, "Invalid nuclear LT path: {0}");
 
         try {
-            Set<String> whitelist = loadCp0Cp1Cp2Whitelist();
+            Set<String> whitelist = loadWhitelist(designation);
             List<String> sheetNames = timeSeriesReader.listSheetNames(ltPath);
 
             List<TimeSeriesMatrixColumn> onglets = new ArrayList<>(sheetNames.size());
@@ -125,7 +149,7 @@ public class NuclearAvailabilityAssemblerServiceImpl implements NuclearAvailabil
 
             TimeSeriesMatrix combined = new TimeSeriesMatrix(onglets);
             byte[] bytes = nasFileService.getWriter().writeToByteArray(combined);
-            return nasFileService.saveMatrixBytesToNas(bytes, ltTrajectory.getFileName() + "_lt", properties.getNuclearAvailabilityTsOutputDirectory());
+            return nasFileService.saveMatrixBytesToNas(bytes, ltTrajectory.getFileName() + "_lt_" + designation, properties.getNuclearAvailabilityTsOutputDirectory());
         } catch (IOException e) {
             throw TechnicalException.builder()
                     .errorMessageArguments(List.of(ltTrajectory.getFileName()))
@@ -135,10 +159,10 @@ public class NuclearAvailabilityAssemblerServiceImpl implements NuclearAvailabil
         }
     }
 
-    private Set<String> loadCp0Cp1Cp2Whitelist() {
-        return clusterDesignationRepository.findByCluster_TypeCluster(CP0_CP1_CP2_DESIGNATION)
+    private Set<String> loadWhitelist(String designation) {
+        return clusterDesignationRepository.findByCluster_TypeCluster(designation)
                 .stream()
-                .map(designation -> designation.getId().getNomCluster())
+                .map(d -> d.getId().getNomCluster())
                 .collect(Collectors.toSet());
     }
 

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/nuclear/impl/NuclearAvailabilityAssemblerServiceImpl.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/nuclear/impl/NuclearAvailabilityAssemblerServiceImpl.java
@@ -163,12 +163,25 @@ public class NuclearAvailabilityAssemblerServiceImpl implements NuclearAvailabil
         return hourly;
     }
 
+    /**
+     * Each EPR column is already a complete, independent series (no sum needed like LT (one "SimuN" column for each MC scenario)
+     * but is still stored in 365 daily format, so it gets the same
+     * x24 hourly duplication, applied per column.
+     */
     private String assembleEprSeries(TrajectoryEntity eprTrajectory, String horizonYear) {
         try {
             Path relativePath = resolvePrefixedRelativePath(properties.getNuclearEprDirectory(),
                     NuclearFilePrefixes.EPR_FILE_PREFIX, eprTrajectory.getFileName());
             Path eprPath = resolveValidatedNasPath(relativePath, "Invalid nuclear EPR path: {0}");
-            return nasFileService.readAndSaveMatrixToNas(eprPath, properties.getNuclearAvailabilityTsOutputDirectory(), horizonYear, true);
+
+            TimeSeriesMatrix pool = nasFileService.readMatrix(eprPath, horizonYear, true,
+                    TrajectoryType.NUCLEAR_FR_TS_ERP.name(), "EPR");
+            List<TimeSeriesMatrixColumn> hourlyColumns = pool.columns().stream()
+                    .map(column -> new TimeSeriesMatrixColumn(column.name(), expandDailyToHourly(column.values())))
+                    .toList();
+
+            byte[] bytes = nasFileService.getWriter().writeToByteArray(new TimeSeriesMatrix(hourlyColumns));
+            return nasFileService.saveMatrixBytesToNas(bytes, eprTrajectory.getFileName() + "_epr", properties.getNuclearAvailabilityTsOutputDirectory());
         } catch (IOException e) {
             throw TechnicalException.builder()
                     .errorMessageArguments(List.of(eprTrajectory.getFileName()))
@@ -179,11 +192,11 @@ public class NuclearAvailabilityAssemblerServiceImpl implements NuclearAvailabil
     }
 
     /**
-     * SMR availability is only prepared here, not fianlized: the raw column pool (without the excluded
-     * "TS_EPR_clim" column) is converted to a single shared Arrow file, and each matched cluster gets
-     * the active unit count and a composed seed string. The seeded "mixage des
-     * chroniques" that combines pool columns per active unit is left for the python
-     * generator
+     * SMR availability is only prepared here, not fianlized: the column pool (without the
+     * "TS_EPR_clim" column, each column expanded x24 for hourly) is converted to a
+     * single shared Arrow file, and each matched cluster gets the active unit count and a composed
+     * seed string. The seeded "mixage des chroniques" that combines pool columns per active unit is
+     * left for the python generator
      */
     private void assembleSmrAvailability(TrajectoryEntity smrTrajectory, String horizonYear,
             Map<AreaClusterRefKey, ThermalClusterGenerationDto> thermalClusterProps,
@@ -227,6 +240,7 @@ public class NuclearAvailabilityAssemblerServiceImpl implements NuclearAvailabil
                     TrajectoryType.NUCLEAR_FR_TS_SMR.name(), "SMR");
             return pool.columns().stream()
                     .filter(column -> !SMR_EXCLUDED_COLUMN.equalsIgnoreCase(column.name()))
+                    .map(column -> new TimeSeriesMatrixColumn(column.name(), expandDailyToHourly(column.values())))
                     .toList();
         } catch (IOException e) {
             throw TechnicalException.builder()

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/nuclear/impl/NuclearAvailabilityAssemblerServiceImpl.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/nuclear/impl/NuclearAvailabilityAssemblerServiceImpl.java
@@ -46,7 +46,6 @@ public class NuclearAvailabilityAssemblerServiceImpl implements NuclearAvailabil
     private static final String FR_AREA = "fr";
     private static final String LT_SIMU_FILE_PREFIX = "Simu_";
     private static final String XLSX_SUFFIX = ".xlsx";
-    private static final String SMR_EXCLUDED_COLUMN = "TS_EPR_clim";
     private static final String SEED_SUFFIX = "seed-tsgen-thermal";
     private static final String CP0_CP1_CP2_DESIGNATION = "cp0_cp1_cp2";
     private static final int HOURS_PER_DAY = 24;
@@ -192,11 +191,10 @@ public class NuclearAvailabilityAssemblerServiceImpl implements NuclearAvailabil
     }
 
     /**
-     * SMR availability is only prepared here, not fianlized: the column pool (without the
-     * "TS_EPR_clim" column, each column expanded x24 for hourly) is converted to a
-     * single shared Arrow file, and each matched cluster gets the active unit count and a composed
-     * seed string. The seeded "mixage des chroniques" that combines pool columns per active unit is
-     * left for the python generator
+     * SMR availability is only prepared here, not fianlized: the column pool (each column expanded
+     * x24 for hourly) is converted to a single shared Arrow file, and each matched cluster gets the
+     * active unit count and a composed seed string. The seeded "mixage des chroniques" that combines
+     * pool columns per active unit is left for the python generator
      */
     private void assembleSmrAvailability(TrajectoryEntity smrTrajectory, String horizonYear,
             Map<AreaClusterRefKey, ThermalClusterGenerationDto> thermalClusterProps,
@@ -209,12 +207,12 @@ public class NuclearAvailabilityAssemblerServiceImpl implements NuclearAvailabil
 
         Map<AreaClusterRefKey, Integer> unitCountByCluster = requireUnitCounts(matchedClusters, thermalClusterProps);
 
-        List<TimeSeriesMatrixColumn> filteredColumns = readFilteredSmrPool(smrTrajectory, horizonYear);
-        if (filteredColumns.isEmpty()) {
+        List<TimeSeriesMatrixColumn> poolColumns = readSmrPool(smrTrajectory, horizonYear);
+        if (poolColumns.isEmpty()) {
             return;
         }
 
-        String arrowFile = writeSharedSmrPool(smrTrajectory, filteredColumns);
+        String arrowFile = writeSharedSmrPool(smrTrajectory, poolColumns);
         for (AreaClusterRefKey key : matchedClusters) {
             seriesByCluster.put(key, arrowFile);
             smrMixageByCluster.put(key, new NuclearSMRMixageDTO(unitCountByCluster.get(key), buildSeed(FR_AREA, key.thermalClusterRef().getName())));
@@ -230,7 +228,7 @@ public class NuclearAvailabilityAssemblerServiceImpl implements NuclearAvailabil
         return unitCountByCluster;
     }
 
-    private List<TimeSeriesMatrixColumn> readFilteredSmrPool(TrajectoryEntity smrTrajectory, String horizonYear) {
+    private List<TimeSeriesMatrixColumn> readSmrPool(TrajectoryEntity smrTrajectory, String horizonYear) {
         try {
             Path relativePath = resolvePrefixedRelativePath(properties.getNuclearSmrDirectory(),
                     NuclearFilePrefixes.SMR_FILE_PREFIX, smrTrajectory.getFileName());
@@ -239,7 +237,6 @@ public class NuclearAvailabilityAssemblerServiceImpl implements NuclearAvailabil
             TimeSeriesMatrix pool = nasFileService.readMatrix(smrPath, horizonYear, true,
                     TrajectoryType.NUCLEAR_FR_TS_SMR.name(), "SMR");
             return pool.columns().stream()
-                    .filter(column -> !SMR_EXCLUDED_COLUMN.equalsIgnoreCase(column.name()))
                     .map(column -> new TimeSeriesMatrixColumn(column.name(), expandDailyToHourly(column.values())))
                     .toList();
         } catch (IOException e) {
@@ -251,9 +248,9 @@ public class NuclearAvailabilityAssemblerServiceImpl implements NuclearAvailabil
         }
     }
 
-    private String writeSharedSmrPool(TrajectoryEntity smrTrajectory, List<TimeSeriesMatrixColumn> filteredColumns) {
+    private String writeSharedSmrPool(TrajectoryEntity smrTrajectory, List<TimeSeriesMatrixColumn> poolColumns) {
         try {
-            byte[] bytes = nasFileService.getWriter().writeToByteArray(new TimeSeriesMatrix(filteredColumns));
+            byte[] bytes = nasFileService.getWriter().writeToByteArray(new TimeSeriesMatrix(poolColumns));
             return nasFileService.saveMatrixBytesToNas(bytes,
                     smrTrajectory.getFileName() + "_smr", properties.getNuclearAvailabilityTsOutputDirectory());
         } catch (IOException e) {

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/nuclear/impl/NuclearAvailabilityAssemblerServiceImpl.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/nuclear/impl/NuclearAvailabilityAssemblerServiceImpl.java
@@ -49,15 +49,15 @@ public class NuclearAvailabilityAssemblerServiceImpl implements NuclearAvailabil
     private static final String SEED_SUFFIX = "seed-tsgen-thermal";
     private static final String CP0_CP1_CP2_DESIGNATION = "cp0_cp1_cp2";
     private static final String N4_DESIGNATION = "n4";
+    private static final String P4_DESIGNATION = "p4";
     private static final int HOURS_PER_DAY = 24;
 
     /**
      * Explicit, not name-derived: which referential designation backs which LT cluster names.
-     * N4 and P4 cluster names share the "n4" designation (p4 is folded into n4
-     * in the referential).
      */
     private static final List<LtDesignationGroup> LT_DESIGNATION_GROUPS = List.of(
-            new LtDesignationGroup(N4_DESIGNATION, NuclearAvailabilityAssemblerServiceImpl::isN4OrP4Cluster),
+            new LtDesignationGroup(N4_DESIGNATION, NuclearClusterNames::isN4),
+            new LtDesignationGroup(P4_DESIGNATION, NuclearClusterNames::isP4),
             new LtDesignationGroup(CP0_CP1_CP2_DESIGNATION, NuclearAvailabilityAssemblerServiceImpl::isDefaultLongTermCluster)
     );
 
@@ -106,12 +106,6 @@ public class NuclearAvailabilityAssemblerServiceImpl implements NuclearAvailabil
         return trajectories.stream()
                 .filter(t -> type.name().equals(t.getType()))
                 .findFirst();
-    }
-
-    private static boolean isN4OrP4Cluster(String clusterName) {
-        return NuclearClusterNames.isNuclear(clusterName)
-                && !NuclearClusterNames.isPeak(clusterName)
-                && (NuclearClusterNames.isN4(clusterName) || NuclearClusterNames.isP4(clusterName));
     }
 
     private static boolean isDefaultLongTermCluster(String clusterName) {

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/nuclear/impl/NuclearAvailabilityAssemblerServiceImpl.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/nuclear/impl/NuclearAvailabilityAssemblerServiceImpl.java
@@ -27,14 +27,7 @@ import org.springframework.stereotype.Service;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -51,6 +44,7 @@ public class NuclearAvailabilityAssemblerServiceImpl implements NuclearAvailabil
     private static final String N4_DESIGNATION = "n4";
     private static final String P4_DESIGNATION = "p4";
     private static final int HOURS_PER_DAY = 24;
+    private static final int MAX_ROWS_PER_YEAR = 365;
 
     /**
      * Explicit, not name-derived: which referential designation backs which LT cluster names.
@@ -137,8 +131,8 @@ public class NuclearAvailabilityAssemblerServiceImpl implements NuclearAvailabil
             List<TimeSeriesMatrixColumn> onglets = new ArrayList<>(sheetNames.size());
             for (String sheetName : sheetNames) {
                 TimeSeriesMatrix selected = timeSeriesReader.readSelectedColumnsFromXlsx(ltPath, sheetName, whitelist);
-                double[] hourly = expandDailyToHourly(sumColumnsRowWise(selected));
-                onglets.add(new TimeSeriesMatrixColumn(sheetName, hourly));
+                    double[] hourly = expandDailyToHourly(sumColumnsRowWise(selected));
+                    onglets.add(new TimeSeriesMatrixColumn(sheetName, hourly));
             }
 
             TimeSeriesMatrix combined = new TimeSeriesMatrix(onglets);
@@ -161,6 +155,9 @@ public class NuclearAvailabilityAssemblerServiceImpl implements NuclearAvailabil
     }
 
     private static double[] sumColumnsRowWise(TimeSeriesMatrix matrix) {
+        if (matrix.columns().isEmpty()) {
+            return new double[MAX_ROWS_PER_YEAR];
+        }
         int rowCount = matrix.getRowCount();
         double[] sums = new double[rowCount];
         for (TimeSeriesMatrixColumn column : matrix.columns()) {

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/nuclear/impl/NuclearFileProcessorServiceImpl.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/nuclear/impl/NuclearFileProcessorServiceImpl.java
@@ -49,8 +49,6 @@ public class NuclearFileProcessorServiceImpl implements NuclearFileProcessorServ
 
     private static final String UNKNOWN_USER = "UNKNOWN";
     private static final String PARAMETERS_FILE_PREFIX = "Parameters_modNuc_";
-    private static final String TS_EPR_FILE_PREFIX = "TS_EPR_";
-    private static final String TS_SMR_FILE_PREFIX = "TS_SMR_";
     private static final String PARAMETERS_FILE_SUFFIX = ".xlsx";
     private static final Set<String> REQUIRED_MODULATION_TYPES = Set.of(
             "nucFR_modul_hourly", "nucFR_modul_daily", "nucFR_modul_weekly"
@@ -587,8 +585,8 @@ public class NuclearFileProcessorServiceImpl implements NuclearFileProcessorServ
 
     private String getFileName(String fileName, TrajectoryType type) {
         String prefix = switch (type) {
-            case NUCLEAR_FR_TS_SMR -> TS_SMR_FILE_PREFIX;
-            case NUCLEAR_FR_TS_ERP -> TS_EPR_FILE_PREFIX;
+            case NUCLEAR_FR_TS_SMR -> NuclearFilePrefixes.SMR_FILE_PREFIX;
+            case NUCLEAR_FR_TS_ERP -> NuclearFilePrefixes.EPR_FILE_PREFIX;
             case NUCLEAR_FR_TALON -> NuclearFilePrefixes.TALON_FILE_PREFIX;
             default -> StringUtils.EMPTY;
         };

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/study/impl/StudyGeneratorServiceImpl.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/study/impl/StudyGeneratorServiceImpl.java
@@ -13,6 +13,8 @@ import com.rte_france.antares.datamanager_back.service.common.impl.NasFileServic
 import com.rte_france.antares.datamanager_back.repository.model.settings.AdequacySettingsEntity;
 import com.rte_france.antares.datamanager_back.service.adequacy.AdequacySettingsAssemblerService;
 import com.rte_france.antares.datamanager_back.service.dsr.DsrGenerationAssemblerService;
+import com.rte_france.antares.datamanager_back.service.nuclear.NuclearAvailabilityAssemblerService;
+import com.rte_france.antares.datamanager_back.service.nuclear.NuclearAvailabilityAssemblyResult;
 import com.rte_france.antares.datamanager_back.service.nuclear.NuclearBindingConstraintAssemblerService;
 import com.rte_france.antares.datamanager_back.service.nuclear.NuclearClusterNames;
 import com.rte_france.antares.datamanager_back.service.hydro.HydroGenerationAssemblerService;
@@ -66,6 +68,7 @@ public class StudyGeneratorServiceImpl implements StudyGeneratorService {
     private final NuclearBindingConstraintAssemblerService nuclearBindingConstraintAssemblerService;
     private final AdequacySettingsAssemblerService adequacySettingsAssemblerService;
     private final AdequacySettingsToJsonService adequacySettingsToJsonService;
+    private final NuclearAvailabilityAssemblerService nuclearAvailabilityAssemblerService;
 
     private static final String PROPERTIES = "properties";
 
@@ -117,7 +120,17 @@ public class StudyGeneratorServiceImpl implements StudyGeneratorService {
 
         // Get thermal cluster generation DTOs for all trajectories in the study
         var thermalClusterProps = thermalPropertiesAssemblerService.assembleForTrajectories(study);
-        TrajectoryDispatchResult dispatchResult = dispatchTrajectories(study, trajectories, thermalClusterProps);
+
+        // Must run before dispatchTrajectories/area JSON assembly because it produces a result keyed by cluster
+        // that both the FR node and y_nuc_modulation node need
+        NuclearAvailabilityAssemblyResult nuclearAvailability = nuclearAvailabilityAssemblerService.assembleAvailability(
+                study, thermalClusterProps);
+
+        TrajectoryDispatchResult dispatchResult = dispatchTrajectories(study, trajectories, thermalClusterProps, nuclearAvailability);
+
+        // y_nuc_modulation is a virtual node that only contains nuclear clusters
+        dispatchResult.nuclearModulationTrajectory().ifPresent(traj ->
+                dispatchResult.areasMap().put("y_nuc_modulation", buildYNucModulationAreaMap(thermalClusterProps, nuclearAvailability)));
 
         Map<String, Object> innerGeneratorMap = buildInnerGeneratorMap(study, dispatchResult, thermalClusterProps);
 
@@ -134,7 +147,8 @@ public class StudyGeneratorServiceImpl implements StudyGeneratorService {
                                              Optional<TrajectoryEntity> nuclearTalonTrajectory) {}
 
     private TrajectoryDispatchResult dispatchTrajectories(StudyEntity study, Set<TrajectoryEntity> trajectories,
-                                                           Map<AreaClusterRefKey, ThermalClusterGenerationDto> thermalClusterProps) {
+                                                           Map<AreaClusterRefKey, ThermalClusterGenerationDto> thermalClusterProps,
+                                                           NuclearAvailabilityAssemblyResult nuclearAvailability) {
         Map<String, Object> areasMap = new TreeMap<>();
         Map<String, Object> linksMap = new TreeMap<>();
         Optional<TrajectoryEntity> nuclearModulationTraj = Optional.empty();
@@ -145,7 +159,7 @@ public class StudyGeneratorServiceImpl implements StudyGeneratorService {
             log.info("Processing trajectory fileName={} type={} area={}", trajectory.getFileName(), trajectory.getType(), trajectory.getArea());
 
             switch (trajectoryType) {
-                case AREA -> buildAreasDataMap(study, trajectory, areasMap, thermalClusterProps);
+                case AREA -> buildAreasDataMap(study, trajectory, areasMap, thermalClusterProps, nuclearAvailability);
                 case LINK -> linksToJsonService.buildLinksDataMap(trajectory, linksMap, study);
                 case ADEQUACY_PATCH -> log.warn("Load trajectory type is managed in AREA  trajectory: {}", trajectory.getFileName());
                 case LOAD ->
@@ -169,7 +183,7 @@ public class StudyGeneratorServiceImpl implements StudyGeneratorService {
                 case NUCLEAR_FR_MODULATION -> nuclearModulationTraj = Optional.of(trajectory);
                 case NUCLEAR_FR_TALON -> nuclearTalonTraj = Optional.of(trajectory);
                 case NUCLEAR_FR_TS_ERP, NUCLEAR_FR_TS_LONG_TERM, NUCLEAR_FR_TS_SMR ->
-                        log.warn("NUCLEAR trajectory assembled separately: {}", trajectory.getFileName());
+                        log.debug("NUCLEAR availability trajectory already assembled before dispatch: {}", trajectory.getFileName());
                 default -> {
                     log.error("Unhandled trajectory type {} for trajectory {}", trajectoryType, trajectory.getFileName());
                     throw TechnicalException.builder().message("Unhandled trajectory for generation: " + trajectoryType).build();
@@ -194,7 +208,7 @@ public class StudyGeneratorServiceImpl implements StudyGeneratorService {
         innerGeneratorMap.put("areas", areasMap);
         innerGeneratorMap.put("links", dispatchResult.linksMap());
 
-        Map<String, Object> bindingConstraints = buildBindingConstraintsMap(study, dispatchResult, thermalClusterProps, areasMap);
+        Map<String, Object> bindingConstraints = buildBindingConstraintsMap(study, dispatchResult, thermalClusterProps);
         if (!bindingConstraints.isEmpty()) {
             innerGeneratorMap.put("binding_constraints", bindingConstraints);
         }
@@ -202,15 +216,12 @@ public class StudyGeneratorServiceImpl implements StudyGeneratorService {
     }
 
     private Map<String, Object> buildBindingConstraintsMap(StudyEntity study, TrajectoryDispatchResult dispatchResult,
-                                                             Map<AreaClusterRefKey, ThermalClusterGenerationDto> thermalClusterProps,
-                                                             Map<String, Object> areasMap) {
+                                                             Map<AreaClusterRefKey, ThermalClusterGenerationDto> thermalClusterProps) {
         Map<String, Object> bindingConstraints = new LinkedHashMap<>();
-        dispatchResult.nuclearModulationTrajectory().ifPresent(traj -> {
-            bindingConstraints.put("nuclear_modulation",
-                    nuclearBindingConstraintAssemblerService.assembleModulationBindingConstraints(
-                            study, traj, extractFrNuclearClusterNames(thermalClusterProps)));
-            areasMap.put("y_nuc_modulation", buildYNucModulationAreaMap(thermalClusterProps));
-        });
+        dispatchResult.nuclearModulationTrajectory().ifPresent(traj ->
+                bindingConstraints.put("nuclear_modulation",
+                        nuclearBindingConstraintAssemblerService.assembleModulationBindingConstraints(
+                                study, traj, extractFrNuclearClusterNames(thermalClusterProps))));
         dispatchResult.nuclearTalonTrajectory().ifPresent(traj ->
                 bindingConstraints.put("nuclear_talon",
                         nuclearBindingConstraintAssemblerService.assembleTalonBindingConstraint(
@@ -220,7 +231,8 @@ public class StudyGeneratorServiceImpl implements StudyGeneratorService {
 
 
     private void buildAreasDataMap(StudyEntity studyEntity, TrajectoryEntity trajectory, Map<String, Object> areasMap,
-                                   Map<AreaClusterRefKey, ThermalClusterGenerationDto> thermalClusterProps) throws BusinessException {
+                                   Map<AreaClusterRefKey, ThermalClusterGenerationDto> thermalClusterProps,
+                                   NuclearAvailabilityAssemblyResult nuclearAvailability) throws BusinessException {
         log.info("Construction des areas data pour trajectory={} area={}", trajectory.getFileName(), trajectory.getArea());
 
         List<AreaDTO> areaDTOs = trajectory.getAreaConfigEntities().stream()
@@ -268,7 +280,7 @@ public class StudyGeneratorServiceImpl implements StudyGeneratorService {
                 }
             }
         }
-        
+
         AreasGenerationContextDTO context = AreasGenerationContextDTO.builder()
                 .arrowLoadFilesByArea(listArrowLoadFilesByArea)
                 .clusterPropsByArea(Optional.ofNullable(thermalClusterProps)
@@ -278,7 +290,7 @@ public class StudyGeneratorServiceImpl implements StudyGeneratorService {
                         .collect(Collectors.groupingBy(
                                 e -> e.getKey().area(),
                                 Collectors.toMap(
-                                        e -> e.getKey().area().toUpperCase(Locale.ROOT) + "_" + e.getKey().thermalClusterRef().getName(),
+                                        e -> thermalToJsonService.buildClusterKey(e.getKey().area(), e.getKey().thermalClusterRef().getName()),
                                         Map.Entry::getValue,
                                         (a, b) -> a,
                                         LinkedHashMap::new
@@ -290,6 +302,8 @@ public class StudyGeneratorServiceImpl implements StudyGeneratorService {
                 .resProps(areaResGenerationMap)
                 .hydroProps(areaHydroGenerationMap)
                 .adequacyModeByArea(adequacyModeByArea)
+                .nuclearSeriesByClusterKey(projectByClusterKey(nuclearAvailability.seriesByCluster()))
+                .nuclearSmrMixageByClusterKey(projectByClusterKey(nuclearAvailability.smrMixageByCluster()))
                 .build();
 
         Map<String, Map<String, Object>> areasDataMap = areaDTOs.stream()
@@ -302,6 +316,13 @@ public class StudyGeneratorServiceImpl implements StudyGeneratorService {
         log.info("Areas data with {} entries", areasDataMap.size());
     }
 
+    private <T> Map<String, T> projectByClusterKey(Map<AreaClusterRefKey, T> byRefKey) {
+        Map<String, T> result = new LinkedHashMap<>();
+        byRefKey.forEach((key, value) -> result.put(
+                thermalToJsonService.buildClusterKey(key.area(), key.thermalClusterRef().getName()), value));
+        return result;
+    }
+
     private List<String> extractFrNuclearClusterNames(Map<AreaClusterRefKey, ThermalClusterGenerationDto> thermalClusterProps) {
         return thermalClusterProps.keySet().stream()
                 .filter(key -> "fr".equalsIgnoreCase(key.area())
@@ -311,22 +332,29 @@ public class StudyGeneratorServiceImpl implements StudyGeneratorService {
                 .toList();
     }
 
-    private Map<String, Object> buildYNucModulationAreaMap(Map<AreaClusterRefKey, ThermalClusterGenerationDto> thermalClusterProps) {
-        Map<String, ThermalClusterGenerationDto> nonPeakNuclearClusters = thermalClusterProps.entrySet().stream()
-                .filter(e -> {
-                    String name = e.getKey().thermalClusterRef().getName();
-                    return "fr".equalsIgnoreCase(e.getKey().area())
-                            && NuclearClusterNames.isNuclear(name) && !NuclearClusterNames.isPeak(name);
-                })
-                .collect(Collectors.toMap(
-                        e -> "y_nuc_modulation_" + e.getKey().thermalClusterRef().getName().toLowerCase(Locale.ROOT),
-                        Map.Entry::getValue,
-                        (a, b) -> a,
-                        LinkedHashMap::new
-                ));
+    private Map<String, Object> buildYNucModulationAreaMap(Map<AreaClusterRefKey, ThermalClusterGenerationDto> thermalClusterProps,
+                                                            NuclearAvailabilityAssemblyResult nuclearAvailability) {
+        Map<String, ThermalClusterGenerationDto> nonPeakNuclearClusters = new LinkedHashMap<>();
+        Map<String, String> yNucSeriesByClusterKey = new LinkedHashMap<>();
+        Map<String, NuclearSMRMixageDTO> yNucSmrMixageByClusterKey = new LinkedHashMap<>();
+
+        for (var entry : thermalClusterProps.entrySet()) {
+            AreaClusterRefKey key = entry.getKey();
+            String name = key.thermalClusterRef().getName();
+            if (!"fr".equalsIgnoreCase(key.area()) || !NuclearClusterNames.isNuclear(name) || NuclearClusterNames.isPeak(name)) {
+                continue;
+            }
+            String yNucKey = "y_nuc_modulation_" + name.toLowerCase(Locale.ROOT);
+            nonPeakNuclearClusters.putIfAbsent(yNucKey, entry.getValue());
+            Optional.ofNullable(nuclearAvailability.seriesByCluster().get(key))
+                    .ifPresent(series -> yNucSeriesByClusterKey.put(yNucKey, series));
+            Optional.ofNullable(nuclearAvailability.smrMixageByCluster().get(key))
+                    .ifPresent(mixage -> yNucSmrMixageByClusterKey.put(yNucKey, mixage));
+        }
 
         Map<String, Object> areaMap = new LinkedHashMap<>();
-        areaMap.put("nuclear", Map.of("clusters", thermalToJsonService.thermalsMapGenerator(nonPeakNuclearClusters)));
+        areaMap.put("nuclear", Map.of("clusters",
+                thermalToJsonService.thermalsMapGenerator(nonPeakNuclearClusters, yNucSeriesByClusterKey, yNucSmrMixageByClusterKey)));
         return areaMap;
     }
 
@@ -357,7 +385,8 @@ public class StudyGeneratorServiceImpl implements StudyGeneratorService {
         }
 
         Map<String, Object> thermalsMap = thermalToJsonService.thermalsMapGenerator(nonNuclearClusters);
-        Map<String, Object> nuclearClustersMap = thermalToJsonService.thermalsMapGenerator(nuclearClusters);
+        Map<String, Object> nuclearClustersMap = thermalToJsonService.thermalsMapGenerator(
+                nuclearClusters, context.getNuclearSeriesByClusterKey(), context.getNuclearSmrMixageByClusterKey());
         Map<String, Object> stsMap = stsToJsonService.stsMapGenerator(areaDTO.getName(), context.getStsClusterProps());
         Map<String, Object> dsrMap = dsrToJsonService.buildDsrDataMap(areaDTO.getName(), context.getDsrClusterProps());
         Map<String, Object> miscMap = miscToJsonService.buildMiscDataMap(areaDTO.getName(), context.getMiscProps());

--- a/src/main/java/com/rte_france/antares/datamanager_back/service/study/impl/ThermalToJsonService.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/service/study/impl/ThermalToJsonService.java
@@ -2,6 +2,7 @@ package com.rte_france.antares.datamanager_back.service.study.impl;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rte_france.antares.datamanager_back.dto.NuclearSMRMixageDTO;
 import com.rte_france.antares.datamanager_back.dto.ThermalClusterGenerationDto;
 import com.rte_france.antares.datamanager_back.service.thermal.impl.ThermalPropertiesAssemblerService;
 import lombok.extern.slf4j.Slf4j;
@@ -21,12 +22,15 @@ public class ThermalToJsonService {
     private static final String DATA = "data";
     private static final String MATRIX_HASH = "matrix hash";
 
+    public String buildClusterKey(String area, String clusterName) {
+        return area.toUpperCase(Locale.ROOT) + "_" + clusterName;
+    }
 
     public  Map<String, ThermalClusterGenerationDto> getClusterPropsForArea(Map<ThermalPropertiesAssemblerService.AreaClusterRefKey, ThermalClusterGenerationDto> areaRefProps, String areaName) {
         return areaRefProps.entrySet().stream()
                 .filter(e -> e.getKey().area().equalsIgnoreCase(areaName))
                 .collect(Collectors.toMap(
-                        e -> e.getKey().area().toUpperCase(Locale.ROOT) + "_" + e.getKey().thermalClusterRef().getName(),
+                        e -> buildClusterKey(e.getKey().area(), e.getKey().thermalClusterRef().getName()),
                         Map.Entry::getValue,
                         (a, b) -> a,
                         LinkedHashMap::new
@@ -34,6 +38,16 @@ public class ThermalToJsonService {
     }
 
     public Map<String, Object> thermalsMapGenerator(Map<String, ThermalClusterGenerationDto> clusterProps) {
+        return thermalsMapGenerator(clusterProps, Collections.emptyMap(), Collections.emptyMap());
+    }
+
+    /**
+     * @param seriesOverrides     final "series" value per cluster key, overriding the placeholder when present
+     * @param smrMixageOverrides  SMR only metadata (active unit count + seed) when present
+     */
+    public Map<String, Object> thermalsMapGenerator(Map<String, ThermalClusterGenerationDto> clusterProps,
+            Map<String, String> seriesOverrides,
+            Map<String, NuclearSMRMixageDTO> smrMixageOverrides) {
         if (clusterProps == null || clusterProps.isEmpty()) {
             log.info("thermalsMapGenerator: missing clusterProps");
             return Collections.emptyMap();
@@ -52,11 +66,16 @@ public class ThermalToJsonService {
 
             Map<String, Object> clusterData = new LinkedHashMap<>();
             clusterData.put(PROPERTIES, propertiesMap);
-            clusterData.put("series", MATRIX_HASH);
+            clusterData.put("series", seriesOverrides.getOrDefault(clusterName, MATRIX_HASH));
             clusterData.put("fuel_cost", MATRIX_HASH);
             clusterData.put("co2_cost", MATRIX_HASH);
             clusterData.put(DATA, dataMap);
             clusterData.put("modulation", dto.getParamModulationTsList());
+
+            NuclearSMRMixageDTO mixage = smrMixageOverrides.get(clusterName);
+            if (mixage != null) {
+                clusterData.put("smr_mixage", Map.of("unit_count", mixage.unitCount(), "seed", mixage.seed()));
+            }
 
             clusterMap.put(clusterName, clusterData);
             log.info("Ajout thermal cluster {} avec {} propriétés", clusterName, propertiesMap.size());

--- a/src/main/java/com/rte_france/antares/datamanager_back/util/timeseries_manager/TimeSeriesReader.java
+++ b/src/main/java/com/rte_france/antares/datamanager_back/util/timeseries_manager/TimeSeriesReader.java
@@ -202,6 +202,27 @@ public final class TimeSeriesReader {
     }
   }
 
+  /**
+   * Lists the sheet names of an Excel file (.xlsx), in workbook order.
+   * Cheap because it doesnt parse row/cell content.
+   */
+  public List<String> listSheetNames(Path xlsxPath) throws IOException {
+    Objects.requireNonNull(xlsxPath);
+    requireFileExists(xlsxPath);
+    try (OPCPackage pkg = OPCPackage.open(xlsxPath.toFile(), PackageAccess.READ)) {
+      XSSFReader.SheetIterator iterator = (XSSFReader.SheetIterator) new XSSFReader(pkg).getSheetsData();
+      List<String> names = new ArrayList<>();
+      while (iterator.hasNext()) {
+        try (InputStream sheetInput = iterator.next()) {
+          names.add(iterator.getSheetName());
+        }
+      }
+      return names;
+    } catch (OpenXML4JException e) {
+      throw new IOException(e);
+    }
+  }
+
   private static void requireFileExists(Path xlsxPath) {
     if (!Files.exists(xlsxPath)) {
       throw TechnicalException.builder()

--- a/src/main/resources/application-localhost.properties
+++ b/src/main/resources/application-localhost.properties
@@ -80,6 +80,8 @@ antares.datamanager.nuclear.smr.directory=specific_nuclear/TS_dispo/SMR
 antares.datamanager.nuclear.modulation.ts.output.directory=output/nuclear_modulation_ts_arrow
 antares.datamanager.nuclear.talon.ts.output.directory=output/nuclear_talon_ts_arrow
 antares.datamanager.settings.directory=parameters/general_data
+antares.datamanager.nuclear.availability.ts.output.directory=output/nuclear_availability_ts_output
+antares.datamanager.trajectory.settings.directory=parameters/general_data
 antares.datamanager.adequacy.directory=adequacy_patch/adqp_c
 
 antares.datamanager.study.json.output.directory=output/study_json

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -98,8 +98,10 @@ antares.datamanager.nuclear.lt.directory=${PEGASE_NUCLEAR_LT_DIRECTORY}
 antares.datamanager.nuclear.smr.directory=${PEGASE_NUCLEAR_SMR_DIRECTORY}
 antares.datamanager.nuclear.modulation.ts.output.directory=${PEGASE_NUCLEAR_MODULATION_TS_OUTPUT_DIRECTORY}
 antares.datamanager.nuclear.talon.ts.output.directory=${PEGASE_NUCLEAR_TALON_TS_OUTPUT_DIRECTORY}
+antares.datamanager.nuclear.availability.ts.output.directory=${PEGASE_NUCLEAR_AVAILABILITY_TS_OUTPUT_DIRECTORY}
 antares.datamanager.adequacy.directory=${PEGASE_ADEQUACY_DIRECTORY}
 antares.datamanager.settings.directory=${PEGASE_TRAJECTORY_SETTINGS_DIRECTORY}
+
 
 antares.datamanager.study.json.output.directory=${PEGASE_STUDY_JSON_OUTPUT_DIRECTORY}
 

--- a/src/main/resources/db/changelog/1.1.0/V60-split-n4-cluster-designation-from-cp0-cp1-cp2.sql
+++ b/src/main/resources/db/changelog/1.1.0/V60-split-n4-cluster-designation-from-cp0-cp1-cp2.sql
@@ -1,0 +1,26 @@
+-- liquibase formatted sql
+-- changeset salemsd:110V060-1
+
+-- The initial cluster_designation (V47) was missing n4
+
+INSERT INTO cluster (type_cluster) VALUES ('n4');
+
+DELETE FROM cluster_designation
+WHERE cluster_id = (SELECT id FROM cluster WHERE type_cluster = 'cp0_cp1_cp2')
+  AND nom_cluster IN (
+    'CHOO2N01', 'CHOO2N02', 'CIVAUN01', 'CIVAUN02',
+    'BVIL7N01', 'BVIL7N02', 'CATTEN01', 'CATTEN02', 'CATTEN03', 'CATTEN04',
+    'FLAMAN01', 'FLAMAN02', 'GOLF5N01', 'GOLF5N02', 'N.SE5N01', 'N.SE5N02',
+    'PALUEN01', 'PALUEN02', 'PALUEN03', 'PALUEN04', 'PENLYN01', 'PENLYN02',
+    'SSAL7N01', 'SSAL7N02'
+  );
+
+INSERT INTO cluster_designation (cluster_id, nom_cluster)
+SELECT (SELECT id FROM cluster WHERE type_cluster = 'n4'), v.nom_cluster
+FROM (VALUES
+    ('CHOO2N01'), ('CHOO2N02'), ('CIVAUN01'), ('CIVAUN02'),
+    ('BVIL7N01'), ('BVIL7N02'), ('CATTEN01'), ('CATTEN02'), ('CATTEN03'), ('CATTEN04'),
+    ('FLAMAN01'), ('FLAMAN02'), ('GOLF5N01'), ('GOLF5N02'), ('N.SE5N01'), ('N.SE5N02'),
+    ('PALUEN01'), ('PALUEN02'), ('PALUEN03'), ('PALUEN04'), ('PENLYN01'), ('PENLYN02'),
+    ('SSAL7N01'), ('SSAL7N02')
+) AS v(nom_cluster);

--- a/src/main/resources/db/changelog/1.1.0/V61-split-p4-cluster-designation-from-n4.sql
+++ b/src/main/resources/db/changelog/1.1.0/V61-split-p4-cluster-designation-from-n4.sql
@@ -1,0 +1,25 @@
+-- liquibase formatted sql
+-- changeset salemsd:110V061-1
+
+
+-- The update cluster_designation (V60) was missing p4
+
+INSERT INTO cluster (type_cluster) VALUES ('p4');
+
+DELETE FROM cluster_designation
+WHERE cluster_id = (SELECT id FROM cluster WHERE type_cluster = 'n4')
+  AND nom_cluster IN (
+    'BVIL7N01', 'BVIL7N02', 'CATTEN01', 'CATTEN02', 'CATTEN03', 'CATTEN04',
+    'FLAMAN01', 'FLAMAN02', 'GOLF5N01', 'GOLF5N02', 'N.SE5N01', 'N.SE5N02',
+    'PALUEN01', 'PALUEN02', 'PALUEN03', 'PALUEN04', 'PENLYN01', 'PENLYN02',
+    'SSAL7N01', 'SSAL7N02'
+  );
+
+INSERT INTO cluster_designation (cluster_id, nom_cluster)
+SELECT (SELECT id FROM cluster WHERE type_cluster = 'p4'), v.nom_cluster
+FROM (VALUES
+    ('BVIL7N01'), ('BVIL7N02'), ('CATTEN01'), ('CATTEN02'), ('CATTEN03'), ('CATTEN04'),
+    ('FLAMAN01'), ('FLAMAN02'), ('GOLF5N01'), ('GOLF5N02'), ('N.SE5N01'), ('N.SE5N02'),
+    ('PALUEN01'), ('PALUEN02'), ('PALUEN03'), ('PALUEN04'), ('PENLYN01'), ('PENLYN02'),
+    ('SSAL7N01'), ('SSAL7N02')
+) AS v(nom_cluster);

--- a/src/main/resources/db/changelog/1.1.0/db.changelog-1.1.0.yaml
+++ b/src/main/resources/db/changelog/1.1.0/db.changelog-1.1.0.yaml
@@ -124,3 +124,5 @@ databaseChangeLog:
       file: classpath*:db/changelog/1.1.0/V58-create-settings-general-parameters-table.sql
   - include:
       file: classpath*:db/changelog/1.1.0/V59-modify-settings-advanced-parameters-table.sql
+  - include:
+      file: classpath*:db/changelog/1.1.0/V60-split-n4-cluster-designation-from-cp0-cp1-cp2.sql

--- a/src/main/resources/db/changelog/1.1.0/db.changelog-1.1.0.yaml
+++ b/src/main/resources/db/changelog/1.1.0/db.changelog-1.1.0.yaml
@@ -126,3 +126,5 @@ databaseChangeLog:
       file: classpath*:db/changelog/1.1.0/V59-modify-settings-advanced-parameters-table.sql
   - include:
       file: classpath*:db/changelog/1.1.0/V60-split-n4-cluster-designation-from-cp0-cp1-cp2.sql
+  - include:
+      file: classpath*:db/changelog/1.1.0/V61-split-p4-cluster-designation-from-n4.sql

--- a/src/test/java/com/rte_france/antares/datamanager_back/repository/ClusterDesignationRepositoryTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/repository/ClusterDesignationRepositoryTest.java
@@ -36,9 +36,18 @@ class ClusterDesignationRepositoryTest {
         List<String> unitNames = result.stream().map(e -> e.getId().getNomCluster()).toList();
 
         assertThat(unitNames)
-                .contains("CHOO2N01", "CIVAUN01", "PALUEN01", "PENLYN01", "FLAMAN01", "FLAMAN02",
-                        "CATTEN01", "BVIL7N01", "GOLF5N01", "N.SE5N01", "SSAL7N01")
-                .doesNotContain("BLAYAN01", "FLAMAN03", "EPR01");
+                .containsExactlyInAnyOrder("CHOO2N01", "CHOO2N02", "CIVAUN01", "CIVAUN02");
+    }
+
+    @Test
+    void findByCluster_TypeCluster_returnsP4Designations() {
+        List<ClusterDesignationEntity> result = repository.findByCluster_TypeCluster("p4");
+
+        List<String> unitNames = result.stream().map(e -> e.getId().getNomCluster()).toList();
+
+        assertThat(unitNames)
+                .contains("PALUEN01", "PENLYN01", "FLAMAN01", "FLAMAN02", "CATTEN01", "BVIL7N01", "GOLF5N01", "N.SE5N01", "SSAL7N01")
+                .doesNotContain("BLAYAN01", "FLAMAN03", "EPR01", "CHOO2N01", "CIVAUN01");
     }
 
     @Test

--- a/src/test/java/com/rte_france/antares/datamanager_back/repository/ClusterDesignationRepositoryTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/repository/ClusterDesignationRepositoryTest.java
@@ -1,0 +1,45 @@
+package com.rte_france.antares.datamanager_back.repository;
+
+import com.rte_france.antares.datamanager_back.repository.model.ClusterDesignationEntity;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@DataJpaTest
+class ClusterDesignationRepositoryTest {
+
+    @Autowired
+    private ClusterDesignationRepository repository;
+
+    @Test
+    void findByCluster_TypeCluster_returnsCp0Cp1Cp2Designations() {
+        List<ClusterDesignationEntity> result = repository.findByCluster_TypeCluster("cp0_cp1_cp2");
+
+        List<String> unitNames = result.stream().map(e -> e.getId().getNomCluster()).toList();
+
+        assertThat(unitNames)
+                .contains("BLAYAN01", "PENLYN01", "CHOO2N01", "CIVAUN01", "PALUEN01", "FLAMAN01", "FLAMAN02")
+                .doesNotContain("FLAMAN03", "EPR01");
+    }
+
+    @Test
+    void findByCluster_TypeCluster_returnsEprDesignations() {
+        List<ClusterDesignationEntity> result = repository.findByCluster_TypeCluster("EPR");
+
+        List<String> unitNames = result.stream().map(e -> e.getId().getNomCluster()).toList();
+
+        assertThat(unitNames).contains("FLAMAN03", "EPR01", "EPR24");
+    }
+
+    @Test
+    void findByCluster_TypeCluster_returnsEmpty_whenTypeUnknown() {
+        assertThat(repository.findByCluster_TypeCluster("does_not_exist")).isEmpty();
+    }
+}

--- a/src/test/java/com/rte_france/antares/datamanager_back/repository/ClusterDesignationRepositoryTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/repository/ClusterDesignationRepositoryTest.java
@@ -25,8 +25,20 @@ class ClusterDesignationRepositoryTest {
         List<String> unitNames = result.stream().map(e -> e.getId().getNomCluster()).toList();
 
         assertThat(unitNames)
-                .contains("BLAYAN01", "PENLYN01", "CHOO2N01", "CIVAUN01", "PALUEN01", "FLAMAN01", "FLAMAN02")
-                .doesNotContain("FLAMAN03", "EPR01");
+                .contains("BLAYAN01", "BUGEYN02", "TRICAN01")
+                .doesNotContain("FLAMAN03", "EPR01", "PENLYN01", "CHOO2N01", "CIVAUN01", "PALUEN01", "FLAMAN01", "FLAMAN02");
+    }
+
+    @Test
+    void findByCluster_TypeCluster_returnsN4Designations() {
+        List<ClusterDesignationEntity> result = repository.findByCluster_TypeCluster("n4");
+
+        List<String> unitNames = result.stream().map(e -> e.getId().getNomCluster()).toList();
+
+        assertThat(unitNames)
+                .contains("CHOO2N01", "CIVAUN01", "PALUEN01", "PENLYN01", "FLAMAN01", "FLAMAN02",
+                        "CATTEN01", "BVIL7N01", "GOLF5N01", "N.SE5N01", "SSAL7N01")
+                .doesNotContain("BLAYAN01", "FLAMAN03", "EPR01");
     }
 
     @Test

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/StudyGeneratorServiceImplTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/StudyGeneratorServiceImplTest.java
@@ -21,6 +21,8 @@ import com.rte_france.antares.datamanager_back.service.hydro.HydroGenerationAsse
 import com.rte_france.antares.datamanager_back.service.misc.MiscGenerationAssemblerService;
 import com.rte_france.antares.datamanager_back.dto.NuclearBindingConstraintGenerationDTO;
 import com.rte_france.antares.datamanager_back.dto.NuclearTalonBindingConstraintGenerationDTO;
+import com.rte_france.antares.datamanager_back.service.nuclear.NuclearAvailabilityAssemblerService;
+import com.rte_france.antares.datamanager_back.service.nuclear.NuclearAvailabilityAssemblyResult;
 import com.rte_france.antares.datamanager_back.service.nuclear.NuclearBindingConstraintAssemblerService;
 import com.rte_france.antares.datamanager_back.service.adequacy.AdequacySettingsAssemblerService;
 import com.rte_france.antares.datamanager_back.service.adequacy.impl.AdequacySettingsAssemblerServiceImpl;
@@ -139,6 +141,9 @@ class StudyGeneratorServiceImplTest {
     @Mock
     private NuclearBindingConstraintAssemblerService nuclearBindingConstraintAssemblerService;
 
+    @Mock
+    private NuclearAvailabilityAssemblerService nuclearAvailabilityAssemblerService;
+
     private final Set<TrajectoryEntity> trajectoryEntityList = new LinkedHashSet<>();
 
     private StudyEntity studyEntity;
@@ -222,6 +227,9 @@ class StudyGeneratorServiceImplTest {
         lenient().when(dsrGenerationAssemblerService.assembleDsrProperties(any())).thenReturn(Collections.emptyMap());
         lenient().when(resGenerationAssemblerService.assembleResProperties(any())).thenReturn(Collections.emptyMap());
         lenient().when(hydroGenerationAssemblerService.assembleHydroProperties(any())).thenReturn(Collections.emptyMap());
+        // Default nuclear availability result is empty to avoid NPE in tests not focused on it
+        lenient().when(nuclearAvailabilityAssemblerService.assembleAvailability(any(), anyMap()))
+                .thenReturn(new NuclearAvailabilityAssemblyResult(Map.of(), Map.of()));
 
         // Delegate Adequacy Settings assembler to real implementation by default
         lenient().doAnswer(inv -> new AdequacySettingsAssemblerServiceImpl().assembleAdequacySettings(inv.getArgument(0)))
@@ -247,6 +255,10 @@ class StudyGeneratorServiceImplTest {
                 .when(thermalToJsonService).getClusterPropsForArea(anyMap(), anyString());
         lenient().doAnswer(inv -> new ThermalToJsonService().thermalsMapGenerator(inv.getArgument(0)))
                 .when(thermalToJsonService).thermalsMapGenerator(anyMap());
+        lenient().doAnswer(inv -> new ThermalToJsonService().thermalsMapGenerator(inv.getArgument(0), inv.getArgument(1), inv.getArgument(2)))
+                .when(thermalToJsonService).thermalsMapGenerator(anyMap(), anyMap(), anyMap());
+        lenient().doAnswer(inv -> new ThermalToJsonService().buildClusterKey(inv.getArgument(0), inv.getArgument(1)))
+                .when(thermalToJsonService).buildClusterKey(anyString(), anyString());
 
         lenient().doAnswer(inv -> new DsrToJsonService().buildDsrDataMap(inv.getArgument(0), inv.getArgument(1)))
                 .when(drsToJsonService).buildDsrDataMap(anyString(),anyMap());
@@ -920,6 +932,49 @@ class StudyGeneratorServiceImplTest {
         Map<String, Object> studyMap = mapper.convertValue(root.get("studyTest"), new TypeReference<>() {});
 
         assertThat(studyMap).doesNotContainKey("binding_constraints");
+    }
+
+    @Test
+    void buildJsonForStudyGeneration_shouldApplyNuclearAvailabilitySeriesBeforeAreaJsonIsBuilt() throws Exception {
+        var areaEntity = AreaEntity.builder().name("FR").build();
+        var areaConfig = AreaConfigEntity.builder().area(areaEntity).unsuppliedEnergyCost(3000.0).spilledEnergyCost(0.0).build();
+        var areaTrajectory = TrajectoryEntity.builder().type("AREA").areaConfigEntities(List.of(areaConfig)).area("FR").build();
+        var ltTraj = TrajectoryEntity.builder().type("NUCLEAR_FR_TS_LONG_TERM").fileName("default_lt").build();
+
+        var study = StudyEntity.builder().id(1).name("studyTest")
+                .trajectories(new LinkedHashSet<>(List.of(areaTrajectory, ltTraj)))
+                .build();
+        when(studyRepository.findById(1)).thenReturn(Optional.of(study));
+        when(antaresDataManagerProperties.getStudyJsonOutputDirectory()).thenReturn("output");
+
+        var nuclearRef = ThermalClusterRef.builder().name("Nuclear_cp0").build();
+        var dto = ThermalClusterGenerationDto.builder().efficiency(100.0).build();
+        var clusterKey = new ThermalPropertiesAssemblerService.AreaClusterRefKey("FR", nuclearRef);
+        Map<ThermalPropertiesAssemblerService.AreaClusterRefKey, ThermalClusterGenerationDto> props = new LinkedHashMap<>();
+        props.put(clusterKey, dto);
+        when(thermalPropertiesAssemblerService.assembleForTrajectories(study)).thenReturn(props);
+
+        // Proves the availability result is computed and threaded through before area JSON is built.
+        when(nuclearAvailabilityAssemblerService.assembleAvailability(any(), anyMap()))
+                .thenReturn(new NuclearAvailabilityAssemblyResult(Map.of(clusterKey, "lt_availability.arrow"), Map.of()));
+
+        studyGeneratorService.buildJsonForStudyGeneration(1);
+
+        // The study passed to the assembler must be the one whose trajectories include the LT trajectory.
+        ArgumentCaptor<StudyEntity> studyCaptor = ArgumentCaptor.forClass(StudyEntity.class);
+        verify(nuclearAvailabilityAssemblerService).assembleAvailability(studyCaptor.capture(), anyMap());
+        assertThat(studyCaptor.getValue().getTrajectories()).contains(ltTraj);
+
+        var mapper = new ObjectMapper();
+        Map<String, Object> root = mapper.readValue(captureGeneratedJson(1), new TypeReference<>() {});
+        Map<String, Object> studyMap = mapper.convertValue(root.get("studyTest"), new TypeReference<>() {});
+        Map<String, Object> areas = mapper.convertValue(studyMap.get("areas"), new TypeReference<>() {});
+        Map<String, Object> frArea = mapper.convertValue(areas.get("FR"), new TypeReference<>() {});
+        Map<String, Object> nuclear = mapper.convertValue(frArea.get("nuclear"), new TypeReference<>() {});
+        Map<String, Object> clusters = mapper.convertValue(nuclear.get("clusters"), new TypeReference<>() {});
+        Map<String, Object> cluster = mapper.convertValue(clusters.get("FR_Nuclear_cp0"), new TypeReference<>() {});
+
+        assertThat(cluster).containsEntry("series", "lt_availability.arrow");
     }
 
     @Test

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/nuclear/impl/NuclearAvailabilityAssemblerServiceImplTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/nuclear/impl/NuclearAvailabilityAssemblerServiceImplTest.java
@@ -46,6 +46,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -103,6 +104,9 @@ class NuclearAvailabilityAssemblerServiceImplTest {
                     ClusterDesignationEntity.builder().id(ClusterDesignationKey.builder().clusterId(2).nomCluster("BLAYAN01").build()).build(),
                     ClusterDesignationEntity.builder().id(ClusterDesignationKey.builder().clusterId(2).nomCluster("BLAYAN02").build()).build()
             ));
+            when(clusterDesignationRepository.findByCluster_TypeCluster("n4")).thenReturn(List.of(
+                    ClusterDesignationEntity.builder().id(ClusterDesignationKey.builder().clusterId(3).nomCluster("CHOO2N01").build()).build()
+            ));
 
             when(timeSeriesReader.listSheetNames(any())).thenReturn(List.of("s1", "s2"));
             when(timeSeriesReader.readSelectedColumnsFromXlsx(any(), eq("s1"), anySet())).thenReturn(new TimeSeriesMatrix(List.of(
@@ -117,7 +121,8 @@ class NuclearAvailabilityAssemblerServiceImplTest {
             capturingWriter = mock(TimeSeriesWriter.class);
             when(capturingWriter.writeToByteArray(any())).thenReturn(new byte[]{1, 2, 3});
             when(nasFileService.getWriter()).thenReturn(capturingWriter);
-            when(nasFileService.saveMatrixBytesToNas(any(), anyString(), anyString())).thenReturn("lt_arrow_file.arrow");
+            when(nasFileService.saveMatrixBytesToNas(any(), contains("_lt_n4"), anyString())).thenReturn("lt_n4_arrow_file.arrow");
+            when(nasFileService.saveMatrixBytesToNas(any(), contains("_lt_cp0_cp1_cp2"), anyString())).thenReturn("lt_cp0_cp1_cp2_arrow_file.arrow");
         }
 
         private TrajectoryEntity ltTrajectory() {
@@ -125,24 +130,28 @@ class NuclearAvailabilityAssemblerServiceImplTest {
         }
 
         @Test
-        void shouldSumWhitelistedColumnsAndExpandDailyToHourly_thenApplyToAllNonPeakNonEprNonSmrClusters() {
+        void shouldRouteEachClusterToItsOwnDesignationGroupFile_thenApplyToAllNonPeakNonEprNonSmrClusters() {
             Map<AreaClusterRefKey, ThermalClusterGenerationDto> props = new LinkedHashMap<>();
             AreaClusterRefKey cp0Key = key("fr", "Nuclear_cp0_cp1_cp2");
             AreaClusterRefKey n4Key = key("fr", "Nuclear_n4");
+            AreaClusterRefKey p4Key = key("fr", "Nuclear_p4");
             AreaClusterRefKey eprKey = key("fr", "Nuclear_epr");
             AreaClusterRefKey smrKey = key("fr", "Nuclear_smr");
             AreaClusterRefKey peakKey = key("fr", "Nuclear_peak1");
             props.put(cp0Key, ThermalClusterGenerationDto.builder().build());
             props.put(n4Key, ThermalClusterGenerationDto.builder().build());
+            props.put(p4Key, ThermalClusterGenerationDto.builder().build());
             props.put(eprKey, ThermalClusterGenerationDto.builder().build());
             props.put(smrKey, ThermalClusterGenerationDto.builder().build());
             props.put(peakKey, ThermalClusterGenerationDto.builder().build());
 
             NuclearAvailabilityAssemblyResult result = assembler.assembleAvailability(studyWith(ltTrajectory()), props);
 
+            // cp0_cp1_cp2 gets its own file; n4 and p4 share the same "n4" designation file
             assertThat(result.seriesByCluster())
-                    .containsEntry(cp0Key, "lt_arrow_file.arrow")
-                    .containsEntry(n4Key, "lt_arrow_file.arrow")
+                    .containsEntry(cp0Key, "lt_cp0_cp1_cp2_arrow_file.arrow")
+                    .containsEntry(n4Key, "lt_n4_arrow_file.arrow")
+                    .containsEntry(p4Key, "lt_n4_arrow_file.arrow")
                     .doesNotContainKey(eprKey)
                     .doesNotContainKey(smrKey)
                     .doesNotContainKey(peakKey);

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/nuclear/impl/NuclearAvailabilityAssemblerServiceImplTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/nuclear/impl/NuclearAvailabilityAssemblerServiceImplTest.java
@@ -1,0 +1,349 @@
+package com.rte_france.antares.datamanager_back.service.nuclear.impl;
+
+import com.rte_france.antares.datamanager_back.configuration.AntaresDataManagerProperties;
+import com.rte_france.antares.datamanager_back.dto.NuclearSMRMixageDTO;
+import com.rte_france.antares.datamanager_back.dto.ThermalClusterGenerationDto;
+import com.rte_france.antares.datamanager_back.dto.TrajectoryType;
+import com.rte_france.antares.datamanager_back.exception.BusinessException;
+import com.rte_france.antares.datamanager_back.exception.TechnicalException;
+import com.rte_france.antares.datamanager_back.repository.ClusterDesignationRepository;
+import com.rte_france.antares.datamanager_back.repository.model.ClusterDesignationEntity;
+import com.rte_france.antares.datamanager_back.repository.model.ClusterDesignationKey;
+import com.rte_france.antares.datamanager_back.repository.model.StudyEntity;
+import com.rte_france.antares.datamanager_back.repository.model.ThermalClusterRef;
+import com.rte_france.antares.datamanager_back.repository.model.TrajectoryEntity;
+import com.rte_france.antares.datamanager_back.service.common.impl.NasFileService;
+import com.rte_france.antares.datamanager_back.service.nuclear.NuclearAvailabilityAssemblyResult;
+import com.rte_france.antares.datamanager_back.service.thermal.impl.ThermalPropertiesAssemblerService.AreaClusterRefKey;
+import com.rte_france.antares.datamanager_back.util.PathSecurityUtil;
+import com.rte_france.antares.datamanager_back.util.timeseries_manager.TimeSeriesMatrix;
+import com.rte_france.antares.datamanager_back.util.timeseries_manager.TimeSeriesMatrixColumn;
+import com.rte_france.antares.datamanager_back.util.timeseries_manager.TimeSeriesReader;
+import com.rte_france.antares.datamanager_back.util.timeseries_manager.TimeSeriesWriter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class NuclearAvailabilityAssemblerServiceImplTest {
+
+    @Mock private NasFileService nasFileService;
+    @Mock private TimeSeriesReader timeSeriesReader;
+    @Mock private AntaresDataManagerProperties properties;
+    @Mock private PathSecurityUtil pathSecurityUtil;
+    @Mock private ClusterDesignationRepository clusterDesignationRepository;
+
+    @InjectMocks
+    private NuclearAvailabilityAssemblerServiceImpl assembler;
+
+    private static final String HORIZON = "2029-2030";
+
+    private Path tempDir;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        tempDir = Files.createTempDirectory("nuc_availability_test_");
+        when(properties.getNasDirectory()).thenReturn(tempDir.toString());
+        when(properties.getTrajectoryFilePath()).thenReturn("INPUT");
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        deleteRecursively(tempDir);
+    }
+
+    private static AreaClusterRefKey key(String area, String clusterName) {
+        return new AreaClusterRefKey(area, ThermalClusterRef.builder().name(clusterName).build());
+    }
+
+    private static StudyEntity studyWith(TrajectoryEntity trajectory) {
+        return StudyEntity.builder().horizon(HORIZON).trajectories(Set.of(trajectory)).build();
+    }
+
+    @Nested
+    class LongTermAvailability {
+
+        private static final String TRAJ_NAME = "BP25_liv3";
+        private TimeSeriesWriter capturingWriter;
+
+        @BeforeEach
+        void setUp() throws IOException {
+            when(properties.getNuclearLtDirectory()).thenReturn("specific_nuclear/TS_dispo");
+            when(properties.getNuclearAvailabilityTsOutputDirectory()).thenReturn("output/nuclear_availability_ts_output");
+
+            when(clusterDesignationRepository.findByCluster_TypeCluster("cp0_cp1_cp2")).thenReturn(List.of(
+                    ClusterDesignationEntity.builder().id(ClusterDesignationKey.builder().clusterId(2).nomCluster("BLAYAN01").build()).build(),
+                    ClusterDesignationEntity.builder().id(ClusterDesignationKey.builder().clusterId(2).nomCluster("BLAYAN02").build()).build()
+            ));
+
+            when(timeSeriesReader.listSheetNames(any())).thenReturn(List.of("s1", "s2"));
+            when(timeSeriesReader.readSelectedColumnsFromXlsx(any(), eq("s1"), anySet())).thenReturn(new TimeSeriesMatrix(List.of(
+                    new TimeSeriesMatrixColumn("BLAYAN01", new double[]{1.0, 2.0}),
+                    new TimeSeriesMatrixColumn("BLAYAN02", new double[]{3.0, 4.0})
+            )));
+            when(timeSeriesReader.readSelectedColumnsFromXlsx(any(), eq("s2"), anySet())).thenReturn(new TimeSeriesMatrix(List.of(
+                    new TimeSeriesMatrixColumn("BLAYAN01", new double[]{10.0}),
+                    new TimeSeriesMatrixColumn("BLAYAN02", new double[]{20.0})
+            )));
+
+            capturingWriter = mock(TimeSeriesWriter.class);
+            when(capturingWriter.writeToByteArray(any())).thenReturn(new byte[]{1, 2, 3});
+            when(nasFileService.getWriter()).thenReturn(capturingWriter);
+            when(nasFileService.saveMatrixBytesToNas(any(), anyString(), anyString())).thenReturn("lt_arrow_file.arrow");
+        }
+
+        private TrajectoryEntity ltTrajectory() {
+            return TrajectoryEntity.builder().type(TrajectoryType.NUCLEAR_FR_TS_LONG_TERM.name()).fileName(TRAJ_NAME).build();
+        }
+
+        @Test
+        void shouldSumWhitelistedColumnsAndExpandDailyToHourly_thenApplyToAllNonPeakNonEprNonSmrClusters() {
+            Map<AreaClusterRefKey, ThermalClusterGenerationDto> props = new LinkedHashMap<>();
+            AreaClusterRefKey cp0Key = key("fr", "Nuclear_cp0_cp1_cp2");
+            AreaClusterRefKey n4Key = key("fr", "Nuclear_n4");
+            AreaClusterRefKey eprKey = key("fr", "Nuclear_epr");
+            AreaClusterRefKey smrKey = key("fr", "Nuclear_smr");
+            AreaClusterRefKey peakKey = key("fr", "Nuclear_peak1");
+            props.put(cp0Key, ThermalClusterGenerationDto.builder().build());
+            props.put(n4Key, ThermalClusterGenerationDto.builder().build());
+            props.put(eprKey, ThermalClusterGenerationDto.builder().build());
+            props.put(smrKey, ThermalClusterGenerationDto.builder().build());
+            props.put(peakKey, ThermalClusterGenerationDto.builder().build());
+
+            NuclearAvailabilityAssemblyResult result = assembler.assembleAvailability(studyWith(ltTrajectory()), props);
+
+            assertThat(result.seriesByCluster())
+                    .containsEntry(cp0Key, "lt_arrow_file.arrow")
+                    .containsEntry(n4Key, "lt_arrow_file.arrow")
+                    .doesNotContainKey(eprKey)
+                    .doesNotContainKey(smrKey)
+                    .doesNotContainKey(peakKey);
+            assertThat(result.smrMixageByCluster()).isEmpty();
+        }
+
+        @Test
+        void shouldWriteOneColumnPerOnglet_withDailyValuesDuplicated24Times() throws IOException {
+            Map<AreaClusterRefKey, ThermalClusterGenerationDto> props = new LinkedHashMap<>();
+            props.put(key("fr", "Nuclear_cp0_cp1_cp2"), ThermalClusterGenerationDto.builder().build());
+
+            assembler.assembleAvailability(studyWith(ltTrajectory()), props);
+
+            ArgumentCaptor<TimeSeriesMatrix> captor = ArgumentCaptor.forClass(TimeSeriesMatrix.class);
+            verify(capturingWriter).writeToByteArray(captor.capture());
+            TimeSeriesMatrix combined = captor.getValue();
+
+            assertThat(combined.columns()).hasSize(2);
+            assertThat(combined.columns().get(0).name()).isEqualTo("s1");
+            assertThat(combined.columns().get(0).values()).hasSize(48);
+            // day 1 sum = 1.0 + 3.0 = 4.0, duplicated across first 24 hourly steps
+            assertThat(combined.columns().get(0).values()[0]).isEqualTo(4.0);
+            assertThat(combined.columns().get(0).values()[23]).isEqualTo(4.0);
+            // day 2 sum = 2.0 + 4.0 = 6.0, duplicated across next 24 hourly steps
+            assertThat(combined.columns().get(0).values()[24]).isEqualTo(6.0);
+            assertThat(combined.columns().get(0).values()[47]).isEqualTo(6.0);
+
+            assertThat(combined.columns().get(1).name()).isEqualTo("s2");
+            assertThat(combined.columns().get(1).values()).hasSize(24);
+            // single day sum = 10.0 + 20.0 = 30.0
+            assertThat(combined.columns().get(1).values()[0]).isEqualTo(30.0);
+        }
+    }
+
+    @Nested
+    class EprAvailability {
+
+        private static final String STORED_NAME = "BP25_ref";
+
+        @BeforeEach
+        void setUp() throws IOException {
+            when(properties.getNuclearEprDirectory()).thenReturn("specific_nuclear/TS_dispo/EPR");
+            when(properties.getNuclearAvailabilityTsOutputDirectory()).thenReturn("output/nuclear_availability_ts_output");
+
+            Path eprDir = tempDir.resolve("INPUT").resolve("specific_nuclear/TS_dispo/EPR");
+            Files.createDirectories(eprDir);
+            Files.createFile(eprDir.resolve("TS_EPR_" + STORED_NAME + ".xlsx"));
+
+            when(nasFileService.readAndSaveMatrixToNas(any(Path.class), anyString(), any(), anyBoolean()))
+                    .thenReturn("epr_arrow_file.arrow");
+        }
+
+        private TrajectoryEntity eprTrajectory(String storedName) {
+            return TrajectoryEntity.builder().type(TrajectoryType.NUCLEAR_FR_TS_ERP.name()).fileName(storedName).build();
+        }
+
+        @Test
+        void shouldReadAndImportEprSeriesAsIs_thenApplyOnlyToEprClusters() throws IOException {
+            Map<AreaClusterRefKey, ThermalClusterGenerationDto> props = new LinkedHashMap<>();
+            AreaClusterRefKey eprKey = key("fr", "Nuclear_epr");
+            AreaClusterRefKey ltKey = key("fr", "Nuclear_cp0_cp1_cp2");
+            props.put(eprKey, ThermalClusterGenerationDto.builder().build());
+            props.put(ltKey, ThermalClusterGenerationDto.builder().build());
+
+            NuclearAvailabilityAssemblyResult result = assembler.assembleAvailability(studyWith(eprTrajectory(STORED_NAME)), props);
+
+            assertThat(result.seriesByCluster())
+                    .containsEntry(eprKey, "epr_arrow_file.arrow")
+                    .doesNotContainKey(ltKey);
+
+            ArgumentCaptor<Path> pathCaptor = ArgumentCaptor.forClass(Path.class);
+            ArgumentCaptor<Boolean> hasHeaderCaptor = ArgumentCaptor.forClass(Boolean.class);
+            verify(nasFileService).readAndSaveMatrixToNas(pathCaptor.capture(), anyString(), eq("2030"), hasHeaderCaptor.capture());
+
+            assertThat(pathCaptor.getValue().toString())
+                    .endsWith(Path.of("specific_nuclear", "TS_dispo", "EPR", "TS_EPR_" + STORED_NAME + ".xlsx").toString());
+            assertThat(hasHeaderCaptor.getValue()).isTrue();
+        }
+
+        @Test
+        void shouldFindFileWithLowercasePrefixCandidate() throws IOException {
+            String storedName = "case_test_epr";
+            Path eprDir = tempDir.resolve("INPUT").resolve("specific_nuclear/TS_dispo/EPR");
+            Files.createFile(eprDir.resolve("ts_epr_" + storedName + ".xlsx"));
+
+            Map<AreaClusterRefKey, ThermalClusterGenerationDto> props = new LinkedHashMap<>();
+            props.put(key("fr", "Nuclear_epr"), ThermalClusterGenerationDto.builder().build());
+
+            assembler.assembleAvailability(studyWith(eprTrajectory(storedName)), props);
+
+            ArgumentCaptor<Path> pathCaptor = ArgumentCaptor.forClass(Path.class);
+            verify(nasFileService).readAndSaveMatrixToNas(pathCaptor.capture(), anyString(), any(), anyBoolean());
+            assertThat(pathCaptor.getValue().toString()).endsWith("ts_epr_" + storedName + ".xlsx");
+        }
+
+        @Test
+        void shouldThrowTechnicalExceptionWhenFileNotFound() {
+            Map<AreaClusterRefKey, ThermalClusterGenerationDto> props = new LinkedHashMap<>();
+            StudyEntity study = studyWith(eprTrajectory("no_such_file"));
+
+            assertThatThrownBy(() -> assembler.assembleAvailability(study, props))
+                    .isInstanceOf(TechnicalException.class);
+        }
+    }
+
+    @Nested
+    class SmrAvailability {
+
+        private static final String STORED_NAME = "BP25_ref";
+        private TimeSeriesWriter capturingWriter;
+
+        @BeforeEach
+        void setUp() throws IOException {
+            when(properties.getNuclearSmrDirectory()).thenReturn("specific_nuclear/TS_dispo/SMR");
+            when(properties.getNuclearAvailabilityTsOutputDirectory()).thenReturn("output/nuclear_availability_ts_output");
+
+            Path smrDir = tempDir.resolve("INPUT").resolve("specific_nuclear/TS_dispo/SMR");
+            Files.createDirectories(smrDir);
+            Files.createFile(smrDir.resolve("TS_SMR_" + STORED_NAME + ".xlsx"));
+
+            capturingWriter = mock(TimeSeriesWriter.class);
+            when(capturingWriter.writeToByteArray(any())).thenReturn(new byte[]{1});
+            when(nasFileService.getWriter()).thenReturn(capturingWriter);
+            when(nasFileService.saveMatrixBytesToNas(any(), anyString(), anyString())).thenReturn("smr_arrow_file.arrow");
+        }
+
+        private TrajectoryEntity smrTrajectory() {
+            return TrajectoryEntity.builder().type(TrajectoryType.NUCLEAR_FR_TS_SMR.name()).fileName(STORED_NAME).build();
+        }
+
+        @Test
+        void shouldExcludeTsEprClimColumn_andWriteOneSharedPassthroughFile() throws IOException {
+            when(nasFileService.readMatrix(any(), any(), anyBoolean(), anyString(), anyString())).thenReturn(new TimeSeriesMatrix(List.of(
+                    new TimeSeriesMatrixColumn("col1", new double[]{1.0, 2.0}),
+                    new TimeSeriesMatrixColumn("col2", new double[]{3.0, 4.0}),
+                    new TimeSeriesMatrixColumn("TS_EPR_clim", new double[]{99.0, 99.0})
+            )));
+
+            Map<AreaClusterRefKey, ThermalClusterGenerationDto> props = new LinkedHashMap<>();
+            AreaClusterRefKey smrKey = key("fr", "Nuclear_smr");
+            props.put(smrKey, ThermalClusterGenerationDto.builder().unitCount(3).build());
+
+            NuclearAvailabilityAssemblyResult result = assembler.assembleAvailability(studyWith(smrTrajectory()), props);
+
+            ArgumentCaptor<TimeSeriesMatrix> captor = ArgumentCaptor.forClass(TimeSeriesMatrix.class);
+            verify(capturingWriter).writeToByteArray(captor.capture());
+            TimeSeriesMatrix writtenPool = captor.getValue();
+
+            // TS_EPR_clim must never reach the written pool
+            assertThat(writtenPool.columns()).hasSize(2);
+            assertThat(writtenPool.columns()).extracting(TimeSeriesMatrixColumn::name).containsExactly("col1", "col2");
+
+            assertThat(result.seriesByCluster()).containsEntry(smrKey, "smr_arrow_file.arrow");
+            assertThat(result.smrMixageByCluster()).containsKey(smrKey);
+            NuclearSMRMixageDTO mixage = result.smrMixageByCluster().get(smrKey);
+            assertThat(mixage.unitCount()).isEqualTo(3);
+            assertThat(mixage.seed()).isEqualTo("frNuclear_smrseed-tsgen-thermal");
+        }
+
+        @Test
+        void shouldShareTheSameArrowFileAcrossMultipleMatchedSmrClusters() throws IOException {
+            when(nasFileService.readMatrix(any(), any(), anyBoolean(), anyString(), anyString())).thenReturn(new TimeSeriesMatrix(List.of(
+                    new TimeSeriesMatrixColumn("col1", new double[]{1.0}),
+                    new TimeSeriesMatrixColumn("col2", new double[]{2.0})
+            )));
+
+            Map<AreaClusterRefKey, ThermalClusterGenerationDto> props = new LinkedHashMap<>();
+            AreaClusterRefKey smrKey1 = key("fr", "Nuclear_smr");
+            AreaClusterRefKey smrKey2 = key("fr", "Nuclear_smr_2");
+            props.put(smrKey1, ThermalClusterGenerationDto.builder().unitCount(1).build());
+            props.put(smrKey2, ThermalClusterGenerationDto.builder().unitCount(2).build());
+
+            NuclearAvailabilityAssemblyResult result = assembler.assembleAvailability(studyWith(smrTrajectory()), props);
+
+            String smrKey2Series = result.seriesByCluster().get(smrKey2);
+            assertThat(result.seriesByCluster()).containsEntry(smrKey1, smrKey2Series);
+            assertThat(result.smrMixageByCluster().get(smrKey1).unitCount()).isEqualTo(1);
+            assertThat(result.smrMixageByCluster().get(smrKey2).unitCount()).isEqualTo(2);
+            // one write only, even with two matched clusters
+            verify(capturingWriter).writeToByteArray(any());
+        }
+
+        @Test
+        void shouldThrowBusinessExceptionWhenSmrClusterHasNoUnitCount() {
+            Map<AreaClusterRefKey, ThermalClusterGenerationDto> props = new LinkedHashMap<>();
+            props.put(key("fr", "Nuclear_smr"), ThermalClusterGenerationDto.builder().build());
+            StudyEntity study = studyWith(smrTrajectory());
+
+            assertThatThrownBy(() -> assembler.assembleAvailability(study, props))
+                    .isInstanceOf(BusinessException.class);
+        }
+    }
+
+    private void deleteRecursively(Path path) throws IOException {
+        if (Files.isDirectory(path)) {
+            try (var entries = Files.list(path)) {
+                for (Path entry : entries.toList()) {
+                    deleteRecursively(entry);
+                }
+            }
+        }
+        Files.deleteIfExists(path);
+    }
+}

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/nuclear/impl/NuclearAvailabilityAssemblerServiceImplTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/nuclear/impl/NuclearAvailabilityAssemblerServiceImplTest.java
@@ -181,6 +181,7 @@ class NuclearAvailabilityAssemblerServiceImplTest {
     class EprAvailability {
 
         private static final String STORED_NAME = "BP25_ref";
+        private TimeSeriesWriter capturingWriter;
 
         @BeforeEach
         void setUp() throws IOException {
@@ -191,8 +192,15 @@ class NuclearAvailabilityAssemblerServiceImplTest {
             Files.createDirectories(eprDir);
             Files.createFile(eprDir.resolve("TS_EPR_" + STORED_NAME + ".xlsx"));
 
-            when(nasFileService.readAndSaveMatrixToNas(any(Path.class), anyString(), any(), anyBoolean()))
-                    .thenReturn("epr_arrow_file.arrow");
+            when(nasFileService.readMatrix(any(Path.class), any(), anyBoolean(), anyString(), anyString())).thenReturn(new TimeSeriesMatrix(List.of(
+                    new TimeSeriesMatrixColumn("Simu1", new double[]{1.0, 2.0}),
+                    new TimeSeriesMatrixColumn("Simu2", new double[]{3.0, 4.0})
+            )));
+
+            capturingWriter = mock(TimeSeriesWriter.class);
+            when(capturingWriter.writeToByteArray(any())).thenReturn(new byte[]{1, 2, 3});
+            when(nasFileService.getWriter()).thenReturn(capturingWriter);
+            when(nasFileService.saveMatrixBytesToNas(any(), anyString(), anyString())).thenReturn("epr_arrow_file.arrow");
         }
 
         private TrajectoryEntity eprTrajectory(String storedName) {
@@ -200,7 +208,7 @@ class NuclearAvailabilityAssemblerServiceImplTest {
         }
 
         @Test
-        void shouldReadAndImportEprSeriesAsIs_thenApplyOnlyToEprClusters() throws IOException {
+        void shouldExpandEachColumnDailyToHourly_thenApplyOnlyToEprClusters() throws IOException {
             Map<AreaClusterRefKey, ThermalClusterGenerationDto> props = new LinkedHashMap<>();
             AreaClusterRefKey eprKey = key("fr", "Nuclear_epr");
             AreaClusterRefKey ltKey = key("fr", "Nuclear_cp0_cp1_cp2");
@@ -215,11 +223,23 @@ class NuclearAvailabilityAssemblerServiceImplTest {
 
             ArgumentCaptor<Path> pathCaptor = ArgumentCaptor.forClass(Path.class);
             ArgumentCaptor<Boolean> hasHeaderCaptor = ArgumentCaptor.forClass(Boolean.class);
-            verify(nasFileService).readAndSaveMatrixToNas(pathCaptor.capture(), anyString(), eq("2030"), hasHeaderCaptor.capture());
+            verify(nasFileService).readMatrix(pathCaptor.capture(), eq("2030"), hasHeaderCaptor.capture(), anyString(), anyString());
 
             assertThat(pathCaptor.getValue().toString())
                     .endsWith(Path.of("specific_nuclear", "TS_dispo", "EPR", "TS_EPR_" + STORED_NAME + ".xlsx").toString());
             assertThat(hasHeaderCaptor.getValue()).isTrue();
+
+            ArgumentCaptor<TimeSeriesMatrix> writtenCaptor = ArgumentCaptor.forClass(TimeSeriesMatrix.class);
+            verify(capturingWriter).writeToByteArray(writtenCaptor.capture());
+            TimeSeriesMatrix written = writtenCaptor.getValue();
+
+            assertThat(written.columns()).hasSize(2);
+            assertThat(written.columns().get(0).name()).isEqualTo("Simu1");
+            assertThat(written.columns().get(0).values()).hasSize(48);
+            assertThat(written.columns().get(0).values()[0]).isEqualTo(1.0);
+            assertThat(written.columns().get(0).values()[23]).isEqualTo(1.0);
+            assertThat(written.columns().get(0).values()[24]).isEqualTo(2.0);
+            assertThat(written.columns().get(0).values()[47]).isEqualTo(2.0);
         }
 
         @Test
@@ -234,7 +254,7 @@ class NuclearAvailabilityAssemblerServiceImplTest {
             assembler.assembleAvailability(studyWith(eprTrajectory(storedName)), props);
 
             ArgumentCaptor<Path> pathCaptor = ArgumentCaptor.forClass(Path.class);
-            verify(nasFileService).readAndSaveMatrixToNas(pathCaptor.capture(), anyString(), any(), anyBoolean());
+            verify(nasFileService).readMatrix(pathCaptor.capture(), any(), anyBoolean(), anyString(), anyString());
             assertThat(pathCaptor.getValue().toString()).endsWith("ts_epr_" + storedName + ".xlsx");
         }
 
@@ -294,6 +314,13 @@ class NuclearAvailabilityAssemblerServiceImplTest {
             // TS_EPR_clim must never reach the written pool
             assertThat(writtenPool.columns()).hasSize(2);
             assertThat(writtenPool.columns()).extracting(TimeSeriesMatrixColumn::name).containsExactly("col1", "col2");
+
+            // each retained column is expanded x24 daily-to-hourly, like LT/EPR
+            assertThat(writtenPool.columns().get(0).values()).hasSize(48);
+            assertThat(writtenPool.columns().get(0).values()[0]).isEqualTo(1.0);
+            assertThat(writtenPool.columns().get(0).values()[23]).isEqualTo(1.0);
+            assertThat(writtenPool.columns().get(0).values()[24]).isEqualTo(2.0);
+            assertThat(writtenPool.columns().get(0).values()[47]).isEqualTo(2.0);
 
             assertThat(result.seriesByCluster()).containsEntry(smrKey, "smr_arrow_file.arrow");
             assertThat(result.smrMixageByCluster()).containsKey(smrKey);

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/nuclear/impl/NuclearAvailabilityAssemblerServiceImplTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/nuclear/impl/NuclearAvailabilityAssemblerServiceImplTest.java
@@ -107,6 +107,9 @@ class NuclearAvailabilityAssemblerServiceImplTest {
             when(clusterDesignationRepository.findByCluster_TypeCluster("n4")).thenReturn(List.of(
                     ClusterDesignationEntity.builder().id(ClusterDesignationKey.builder().clusterId(3).nomCluster("CHOO2N01").build()).build()
             ));
+            when(clusterDesignationRepository.findByCluster_TypeCluster("p4")).thenReturn(List.of(
+                    ClusterDesignationEntity.builder().id(ClusterDesignationKey.builder().clusterId(4).nomCluster("PALUEN01").build()).build()
+            ));
 
             when(timeSeriesReader.listSheetNames(any())).thenReturn(List.of("s1", "s2"));
             when(timeSeriesReader.readSelectedColumnsFromXlsx(any(), eq("s1"), anySet())).thenReturn(new TimeSeriesMatrix(List.of(
@@ -122,6 +125,7 @@ class NuclearAvailabilityAssemblerServiceImplTest {
             when(capturingWriter.writeToByteArray(any())).thenReturn(new byte[]{1, 2, 3});
             when(nasFileService.getWriter()).thenReturn(capturingWriter);
             when(nasFileService.saveMatrixBytesToNas(any(), contains("_lt_n4"), anyString())).thenReturn("lt_n4_arrow_file.arrow");
+            when(nasFileService.saveMatrixBytesToNas(any(), contains("_lt_p4"), anyString())).thenReturn("lt_p4_arrow_file.arrow");
             when(nasFileService.saveMatrixBytesToNas(any(), contains("_lt_cp0_cp1_cp2"), anyString())).thenReturn("lt_cp0_cp1_cp2_arrow_file.arrow");
         }
 
@@ -147,11 +151,11 @@ class NuclearAvailabilityAssemblerServiceImplTest {
 
             NuclearAvailabilityAssemblyResult result = assembler.assembleAvailability(studyWith(ltTrajectory()), props);
 
-            // cp0_cp1_cp2 gets its own file; n4 and p4 share the same "n4" designation file
+            // cp0_cp1_cp2, n4, and p4 each get their own, distinct file
             assertThat(result.seriesByCluster())
                     .containsEntry(cp0Key, "lt_cp0_cp1_cp2_arrow_file.arrow")
                     .containsEntry(n4Key, "lt_n4_arrow_file.arrow")
-                    .containsEntry(p4Key, "lt_n4_arrow_file.arrow")
+                    .containsEntry(p4Key, "lt_p4_arrow_file.arrow")
                     .doesNotContainKey(eprKey)
                     .doesNotContainKey(smrKey)
                     .doesNotContainKey(peakKey);

--- a/src/test/java/com/rte_france/antares/datamanager_back/service/nuclear/impl/NuclearAvailabilityAssemblerServiceImplTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/service/nuclear/impl/NuclearAvailabilityAssemblerServiceImplTest.java
@@ -294,11 +294,10 @@ class NuclearAvailabilityAssemblerServiceImplTest {
         }
 
         @Test
-        void shouldExcludeTsEprClimColumn_andWriteOneSharedPassthroughFile() throws IOException {
+        void shouldWriteOneSharedPoolWithAllColumnsExpandedHourly() throws IOException {
             when(nasFileService.readMatrix(any(), any(), anyBoolean(), anyString(), anyString())).thenReturn(new TimeSeriesMatrix(List.of(
                     new TimeSeriesMatrixColumn("col1", new double[]{1.0, 2.0}),
-                    new TimeSeriesMatrixColumn("col2", new double[]{3.0, 4.0}),
-                    new TimeSeriesMatrixColumn("TS_EPR_clim", new double[]{99.0, 99.0})
+                    new TimeSeriesMatrixColumn("col2", new double[]{3.0, 4.0})
             )));
 
             Map<AreaClusterRefKey, ThermalClusterGenerationDto> props = new LinkedHashMap<>();
@@ -311,7 +310,7 @@ class NuclearAvailabilityAssemblerServiceImplTest {
             verify(capturingWriter).writeToByteArray(captor.capture());
             TimeSeriesMatrix writtenPool = captor.getValue();
 
-            // TS_EPR_clim must never reach the written pool
+            // every column from the source pool is kept — no exclusion
             assertThat(writtenPool.columns()).hasSize(2);
             assertThat(writtenPool.columns()).extracting(TimeSeriesMatrixColumn::name).containsExactly("col1", "col2");
 

--- a/src/test/java/com/rte_france/antares/datamanager_back/util/timeseries_manager/TimeSeriesReaderTest.java
+++ b/src/test/java/com/rte_france/antares/datamanager_back/util/timeseries_manager/TimeSeriesReaderTest.java
@@ -15,6 +15,7 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -362,5 +363,29 @@ class TimeSeriesReaderTest {
 
         assertEquals("Horizon {0} does not exist in file: {1}", ex.getMessage());
         assertEquals("2030", ex.getErrorMessageArguments().getFirst());
+    }
+
+    @Test
+    void listSheetNames_shouldReturnAllSheetNamesInOrder(@TempDir Path tempDir) throws Exception {
+        Path file = tempDir.resolve("multi-sheet.xlsx");
+        try (Workbook wb = new XSSFWorkbook()) {
+            wb.createSheet("2029");
+            wb.createSheet("2030");
+            wb.createSheet("2031");
+            try (OutputStream os = Files.newOutputStream(file)) {
+                wb.write(os);
+            }
+        }
+
+        var sheetNames = timeSeriesReader.listSheetNames(file);
+
+        assertEquals(List.of("2029", "2030", "2031"), sheetNames);
+    }
+
+    @Test
+    void listSheetNames_shouldThrowTechnicalExceptionWhenFileMissing(@TempDir Path tempDir) {
+        Path file = tempDir.resolve("does-not-exist.xlsx");
+
+        assertThrows(TechnicalException.class, () -> timeSeriesReader.listSheetNames(file));
     }
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -63,6 +63,7 @@ antares.datamanager.nuclear.smr.directory=specific_nuclear/TS_dispo/SMR
 antares.datamanager.settings.directory=parameters/general_data
 antares.datamanager.nuclear.modulation.ts.output.directory=output/nuclear_modulation_ts_arrow
 antares.datamanager.nuclear.talon.ts.output.directory=output/nuclear_talon_ts_arrow
+antares.datamanager.nuclear.availability.ts.output.directory=output/nuclear_availability_ts_output
 
 antares.datamanager.adequacy.directory=adequacy_patch/adqp_c
 


### PR DESCRIPTION
Si mergé -> ne pas oublier la partie générateur aussi https://github.com/AntaresSimulatorTeam/antares-datamanager-generator/pull/71

Le service :

Identifie les trajectoires nucléaires présentes dans l'étude.
Génère les séries horaires de disponibilité.
Sauvegarde les chroniques dans le NAS au format Arrow.
Associe les chroniques aux clusters thermiques concernés.
Prépare les paramètres de mixage pour les clusters SMR.

StudyEntity
     |
     v
assembleAvailability()
     |
     +--> LT ?
     |       |
     |       +--> lecture Excel
     |       +--> somme CP0/CP1/CP2 et n4/p4 => après récupération des noms de cluster selon type (cp0_cp1_cp2, n4), au niveau des onglets, somme pour chaque ligne, des capacités des clusters autorisés 
     |       +--> x24 (conversion journalière → horaire : chaque valeur quotidienne est répétée 24 fois)
     |       +--> Arrow LT
     |
     +--> EPR ?
     |       |
     |       +--> lecture matrice
     |       +--> x24 (conversion journalière → horaire : chaque valeur quotidienne est répétée 24 fois)
     |       +--> Arrow EPR
     |
     +--> SMR ?
             |
             +--> contrôle unitCount
             +--> lecture matrice
             +--> x24 (conversion journalière → horaire : chaque valeur quotidienne est répétée 24 fois)
             +--> Arrow SMR
             +--> génération Seed
             +--> NuclearSMRMixageDTO